### PR TITLE
Verbesserungen am VDV452-Import

### DIFF
--- a/.env
+++ b/.env
@@ -8,9 +8,9 @@ VCC_API_HOSTNAME=localhost
 VCC_API_PORT=9921
 VCC_API_DATA_DIRECTORY=C:/VisualStudioCode/VdvCountCore/Storage/Data
 
-VCC_PROXY_SSL_CERT_FILENAME=ssl-cert.pem
-VCC_PROXY_SSL_CHAIN_FILEMAME=ssl-chain.pem
-VCC_PROXY_SSL_KEY_FILENAME=ssl-key.pem
+VCC_PROXY_SSL_CERT_FILENAME=C:/VisualStudioCode/VdvCountCore/Storage/Certs/ssl-cert.pem
+VCC_PROXY_SSL_CHAIN_FILEMAME=C:/VisualStudioCode/VdvCountCore/Storage/Certs/ssl-chain.pem
+VCC_PROXY_SSL_KEY_FILENAME=C:/VisualStudioCode/VdvCountCore/Storage/Certs/ssl-key.pem
 
 VCC_VDV452_IMPORT_INTERVAL=60
 VCC_VDV452_IMPORT_DIRECTORY=C:/VisualStudioCode/VdvCountCore/Storage/Input/VDV

--- a/src/vcclib/filesystem.py
+++ b/src/vcclib/filesystem.py
@@ -7,9 +7,9 @@ def directory_contains_files(directory: str) -> bool:
     with os.scandir(directory) as entries:
         return any(e.is_file() for e in entries)
     
-def archive_directory_files(directory: str) -> None:
+def archive_directory_files(directory: str, defective: bool = False) -> None:
     if directory_contains_files(directory):
-        archive_directory = os.path.join(directory, 'Archive', datetime.now().strftime('%Y%m%d%H%M%S'))
+        archive_directory = os.path.join(directory, 'Archive' if not defective else 'Defective', datetime.now().strftime('%Y%m%d%H%M%S'))
         os.makedirs(archive_directory)
 
         with os.scandir(directory) as entries:

--- a/src/vcclib/filesystem.py
+++ b/src/vcclib/filesystem.py
@@ -1,0 +1,21 @@
+import os
+import shutil
+
+from datetime import datetime
+
+def directory_contains_files(directory: str) -> bool:
+    with os.scandir(directory) as entries:
+        return any(e.is_file() for e in entries)
+    
+def archive_directory_files(directory: str) -> None:
+    if directory_contains_files(directory):
+        archive_directory = os.path.join(directory, 'Archive', datetime.now().strftime('%Y%m%d%H%M%S'))
+        os.makedirs(archive_directory)
+
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                if entry.is_file():
+                    s = entry.path
+                    d = os.path.join(archive_directory, entry.name)
+
+                    shutil.move(s, d)

--- a/src/vcclib/model.py
+++ b/src/vcclib/model.py
@@ -57,7 +57,7 @@ class Stop(SQLObject):
     def departures(cls, parent_stop_id:int):
         stops = cls.select(Stop.q.parent_id == parent_stop_id)
 
-        return StopTime.select(IN(StopTime.q.stop, stops)).orderBy(StopTime.q.departure_timestamp)
+        return StopTime.select((IN(StopTime.q.stop, stops)) & (StopTime.q.departure_timestamp is not None)).orderBy(StopTime.q.departure_timestamp)
 
 class Line(SQLObject):
     line_id = IntCol()
@@ -80,7 +80,7 @@ class StopTime(SQLObject):
     trip = ForeignKey('Trip', cascade=True)
     stop = ForeignKey('Stop', cascade=True)
     arrival_timestamp = IntCol()
-    departure_timestamp = IntCol()
+    departure_timestamp = IntCol(default=None)
     sequence = IntCol()
 
 class MasterDataVehicle(SQLObject):

--- a/src/vcclib/model.py
+++ b/src/vcclib/model.py
@@ -57,7 +57,7 @@ class Stop(SQLObject):
     def departures(cls, parent_stop_id:int):
         stops = cls.select(Stop.q.parent_id == parent_stop_id)
 
-        return StopTime.select((IN(StopTime.q.stop, stops)) & (StopTime.q.departure_timestamp is not None)).orderBy(StopTime.q.departure_timestamp)
+        return StopTime.select((IN(StopTime.q.stop, stops)) & (StopTime.q.departure_timestamp != None)).orderBy(StopTime.q.departure_timestamp)
 
 class Line(SQLObject):
     line_id = IntCol()

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -284,6 +284,9 @@ class DefaultAdapter(BaseAdapter):
                             if trip_id in trip_waiting_time_index and stop_id in trip_waiting_time_index[trip_id]:
                                 departure_timestamp = departure_timestamp + trip_waiting_time_index[trip_id][stop_id]
 
+                            if s == len(_intermediate_stops) - 1:
+                                departure_timestamp = None
+
                             StopTime(
                                 stop=stop_index[stop_id],
                                 trip=trip,

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -255,7 +255,7 @@ class DefaultAdapter(BaseAdapter):
                         # note, that the start timestamp of 'today' is already UTC, but the record['FRT_START'] is in local time of the system which has
                         # exported the data. So we need to convert the whole thing to UTC before proceeding ... see #5 for more information
                         _start_time_local = int(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.utc).timestamp()) + record['FRT_START']
-                        _start_time_utc = int(datetime.fromtimestamp(_start_time_local, tz=pytz.timezone(timezone)).astimezone(pytz.utc).timestamp)
+                        _start_time_utc = int(datetime.fromtimestamp(_start_time_local, tz=pytz.timezone(timezone)).astimezone(pytz.utc).timestamp())
 
                         # create working variables
                         _line_variant_id = record['STR_LI_VAR']

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -298,6 +298,11 @@ class DefaultAdapter(BaseAdapter):
             raise FileNotFoundError(f"Required file {x10_rec_frt_filename} not found")
 
     def _internal_read_x10_file(self, input_directory: str, x10filename: str) -> X10File:
+        for entry in os.listdir(input_directory):
+            if entry.lower() == x10filename.lower():
+                x10filename = entry
+                break
+        
         x10filename = os.path.join(input_directory, x10filename)
 
         if not os.path.exists(x10filename) or not os.path.isfile(x10filename):

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -255,7 +255,7 @@ class DefaultAdapter(BaseAdapter):
                         # note, that the start timestamp of 'today' is already UTC, but the record['FRT_START'] is in local time of the system which has
                         # exported the data. So we need to convert the whole thing to UTC before proceeding ... see #5 for more information
                         _start_time_local = int(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.utc).timestamp()) + record['FRT_START']
-                        _start_time_utc = datetime.fromtimestamp(_start_time_local, tz=pytz.timezone(timezone)).astimezone(pytz.utc)
+                        _start_time_utc = int(datetime.fromtimestamp(_start_time_local, tz=pytz.timezone(timezone)).astimezone(pytz.utc).timestamp)
 
                         # create working variables
                         _line_variant_id = record['STR_LI_VAR']

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -21,7 +21,8 @@ class DefaultAdapter(BaseAdapter):
     def process(self, input_directory: str) -> None:
 
         # verify input directory and files present
-        self._verify(input_directory)
+        if not self._verify(input_directory):
+            return
         
         # define processing variables
         batch_size = 2500
@@ -34,288 +35,302 @@ class DefaultAdapter(BaseAdapter):
         Trip.deleteMany(where=None)
         StopTime.deleteMany(where=None)
 
-        # load network data ...
-        logging.info('Loading network data ...')
+        try:
+            # keep track of every error to archive import files correctly
+            error_raised = False
 
-        # load and import stop objects
-        stop_index = dict()
+            # load network data ...
+            logging.info('Loading network data ...')
 
-        transaction = database.connection().transaction()
-        transaction_count = 0
+            # load and import stop objects
+            stop_index = dict()
 
-        x10_rec_ort = self._internal_read_x10_file(input_directory, 'rec_ort.x10')
-        for i, record in enumerate(x10_rec_ort.records):
-            try:
-                if record['ONR_TYP_NR'] == 1:
-                    stop_id = record['ORT_NR']
-                    name = record['ORT_REF_ORT_NAME']
-                    latitude = self._convert_coordinate(record['ORT_POS_BREITE'])
-                    longitude = self._convert_coordinate(record['ORT_POS_LAENGE'])
-                    parent_id = record['ORT_REF_ORT']
+            transaction = database.connection().transaction()
+            transaction_count = 0
 
-                    if 'HST_NR_INTERNATIONAL' in record:
-                        international_id = record['HST_NR_INTERNATIONAL']
-                    elif 'ORT_GLOBAL_ID' in record:
-                        international_id = record['ORT_GLOBAL_ID']
-                    else:
-                        international_id = None
+            x10_rec_ort = self._internal_read_x10_file(input_directory, 'rec_ort.x10')
+            for i, record in enumerate(x10_rec_ort.records):
+                try:
+                    if record['ONR_TYP_NR'] == 1:
+                        stop_id = record['ORT_NR']
+                        name = record['ORT_REF_ORT_NAME']
+                        latitude = self._convert_coordinate(record['ORT_POS_BREITE'])
+                        longitude = self._convert_coordinate(record['ORT_POS_LAENGE'])
+                        parent_id = record['ORT_REF_ORT']
 
-                    stop_index[stop_id] = Stop(
-                        stop_id=stop_id,
-                        name=name,
-                        latitude=latitude,
-                        longitude=longitude,
-                        international_id=international_id,
-                        parent_id=parent_id,
-                        connection=transaction
-                    )
+                        if 'HST_NR_INTERNATIONAL' in record:
+                            international_id = record['HST_NR_INTERNATIONAL']
+                        elif 'ORT_GLOBAL_ID' in record:
+                            international_id = record['ORT_GLOBAL_ID']
+                        else:
+                            international_id = None
 
-                if transaction_count >= batch_size or i >= len(x10_rec_ort.records) - 1:
-                    transaction.commit()
-
-                    transaction = database.connection().transaction()
-                    transaction_count = 0
-
-            except Exception as ex:
-                transaction.rollback()
-
-                if not i >= len(x10_rec_ort.records):
-                    transaction = database.connection().transaction()
-
-                logging.exception(ex)
-
-        x10_rec_ort.close()
-
-        # load and import line objects
-        line_index = dict()
-        line_direction_index = dict()
-
-        transaction = database.connection().transaction()
-        transation_count = 0
-
-        x10_rec_lid = self._internal_read_x10_file(input_directory, 'rec_lid.x10')
-        for i, record in enumerate(x10_rec_lid.records):
-            try:
-                line_id = record['LI_NR']
-                line_variant_id = record['STR_LI_VAR']
-                direction = record['LI_RI_NR']
-                name = record['LI_KUERZEL']
-                
-                if 'LinienID' in record:
-                    international_id = record['LinienID']
-                else:
-                    international_id = None
-
-                if (line_id, line_variant_id) not in line_direction_index:
-                    line_direction_index[(line_id, line_variant_id)] = direction
-
-                if line_id not in line_index:
-                    line_index[line_id] = Line(
-                        line_id=line_id, 
-                        name=name, 
-                        connection=transaction
-                    )
-
-                    transation_count = transation_count + 1
-
-                if transation_count >= batch_size or i >= len(x10_rec_lid.records) - 1:
-                    transaction.commit()
-
-                    transaction = database.connection().transaction()
-                    transation_count = 0
-
-            except Exception as ex:
-                transaction.rollback()
-
-                if not i >= len(x10_rec_lid.records) - 1:
-                    transaction = database.connection().transaction()
-
-                logging.exception(ex)
-    
-        x10_rec_lid.close()
-
-        # load timetable information data ...  
-        logging.info('Loading timetable information data ...')
-
-        daytype = None
-        x10_firmenkalender = self._internal_read_x10_file(input_directory, 'firmenkalender.x10')
-        for record in x10_firmenkalender.records:
-            if datetime.now().strftime('%Y%m%d') == str(record['BETRIEBSTAG']):
-                daytype = record['TAGESART_NR']
-                break
-
-        x10_firmenkalender.close()
-
-        if daytype == None:
-            raise ValueError(f"No valid daytype number found for {datetime.now().strftime('%Y%m%d')}")
-        
-        logging.info(f"Using daytype number {daytype}")
-
-        # load routes for each line
-        line_route_index = dict()
-        x10_lid_verlauf = self._internal_read_x10_file(input_directory, 'lid_verlauf.x10')
-        for record in x10_lid_verlauf.records:
-            if record['ONR_TYP_NR'] == 1:
-                line_id = record['LI_NR']
-                line_variant_id = record['STR_LI_VAR']
-                stop_nr = record['ORT_NR']
-
-                if (line_id, line_variant_id) not in line_route_index:
-                    line_route_index[(line_id, line_variant_id)] = list()
-
-                line_route_index[(line_id, line_variant_id)].append(stop_nr)
-
-        x10_lid_verlauf.close()
-
-        # load time demand types
-        time_demand_type_index = dict()
-        x10_sel_fzt_feld = self._internal_read_x10_file(input_directory, 'sel_fzt_feld.x10')
-        for record in x10_sel_fzt_feld.records:
-            if record['ONR_TYP_NR'] == 1 and record['SEL_ZIEL_TYP'] == 1:
-                tdt_id = record['FGR_NR']
-                start_stop_id = record['ORT_NR']
-                dest_stop_id = record['SEL_ZIEL']
-                time_demand_seconds = record['SEL_FZT']
-
-                if tdt_id not in time_demand_type_index:
-                    time_demand_type_index[tdt_id] = dict()
-
-                if start_stop_id not in time_demand_type_index[tdt_id]:
-                    time_demand_type_index[tdt_id][start_stop_id] = dict()
-
-                if dest_stop_id not in time_demand_type_index[tdt_id][start_stop_id]:
-                    time_demand_type_index[tdt_id][start_stop_id][dest_stop_id] = dict()
-
-                time_demand_type_index[tdt_id][start_stop_id][dest_stop_id] = time_demand_seconds
-
-        x10_sel_fzt_feld.close()
-
-        # load stop based waiting time index
-        stop_waiting_time_index = dict()
-
-        x10_ort_hztf = self._internal_read_x10_file(input_directory, 'ort_hztf.x10')
-        for record in x10_ort_hztf.records:
-            if record['ONR_TYP_NR'] == 1:
-                tdt_id = record['FGR_NR']
-                stop_id = record['ORT_NR']
-                waiting_time_seconds = record['HP_HZT']
-
-                if tdt_id not in stop_waiting_time_index:
-                    stop_waiting_time_index[tdt_id] = dict()
-                    
-                stop_waiting_time_index[tdt_id][stop_id] = waiting_time_seconds
-
-        x10_ort_hztf.close()
-
-        # load trip based waiting time index
-        trip_waiting_time_index = dict()
-
-        x10_rec_frt_hzt = self._internal_read_x10_file(input_directory, 'rec_frt_hzt.x10')
-        for record in x10_rec_frt_hzt.records:
-            if record['ONR_TYP_NR'] == 1:
-                trip_id = record['FRT_FID']
-                stop_id = record['ORT_NR']
-                waiting_time_seconds = record['FRT_HZT_ZEIT']
-
-                if trip_id not in trip_waiting_time_index:
-                    trip_waiting_time_index[trip_id] = dict()
-
-                trip_waiting_time_index[trip_id][stop_id] = waiting_time_seconds
-
-        x10_rec_frt_hzt.close()
-
-        # load and generate trips
-        logging.info('Generating trips ...')
-
-        trip_index = dict()
-
-        transaction = database.connection().transaction()
-        transaction_count = 0
-
-        x10_rec_frt = self._internal_read_x10_file(input_directory, 'rec_frt.x10')
-        for i, record in enumerate(x10_rec_frt.records):
-            try:
-                if record['TAGESART_NR'] == daytype:
-
-                    trip_id = record['FRT_FID']
-                    line_id = record['LI_NR']
-                    international_id = None
-
-                    _line_variant_id = record['STR_LI_VAR']
-                    _tdt_id = record['FGR_NR']
-                    _last_timestamp = int(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0).timestamp()) + record['FRT_START']
-                    _intermediate_stops = line_route_index[(line_id, _line_variant_id)]
-
-                    direction = line_direction_index[(line_id, _line_variant_id)]
-
-                    trip = Trip(
-                        trip_id=trip_id, 
-                        line=line_index[line_id],
-                        direction=direction,
-                        international_id=international_id,
-                        connection=transaction
-                    )
-
-                    for s in range(0, len(_intermediate_stops)):
-                        stop_id = _intermediate_stops[s]
-                        arrival_timestamp = _last_timestamp
-                        departure_timestamp = arrival_timestamp
-
-                        if _tdt_id in stop_waiting_time_index and stop_id in stop_waiting_time_index[_tdt_id]:
-                            departure_timestamp = departure_timestamp + stop_waiting_time_index[_tdt_id][stop_id]
-
-                        if trip_id in trip_waiting_time_index and stop_id in trip_waiting_time_index[trip_id]:
-                            departure_timestamp = departure_timestamp + trip_waiting_time_index[trip_id][stop_id]
-
-                        StopTime(
-                            stop=stop_index[stop_id],
-                            trip=trip,
-                            arrival_timestamp=arrival_timestamp,
-                            departure_timestamp=departure_timestamp,
-                            sequence=s + 1,
+                        stop_index[stop_id] = Stop(
+                            stop_id=stop_id,
+                            name=name,
+                            latitude=latitude,
+                            longitude=longitude,
+                            international_id=international_id,
+                            parent_id=parent_id,
                             connection=transaction
                         )
 
-                        if s < len(_intermediate_stops) - 1:
-                            next_stop_id = _intermediate_stops[s + 1]
+                    if transaction_count >= batch_size or i >= len(x10_rec_ort.records) - 1:
+                        transaction.commit()
 
-                            _last_timestamp = departure_timestamp + time_demand_type_index[_tdt_id][stop_id][next_stop_id]
+                        transaction = database.connection().transaction()
+                        transaction_count = 0
 
-                    trip.headsign = stop_index[_intermediate_stops[-1]].name
+                except Exception as ex:
+                    transaction.rollback()
 
-                    trip_index[trip.trip_id] = trip
-                    transaction_count = transaction_count + 1
+                    if not i >= len(x10_rec_ort.records):
+                        transaction = database.connection().transaction()
 
-                if transaction_count >= batch_size or i >= len(x10_rec_frt.records) - 1:
-                    transaction.commit()
+                    logging.exception(ex)
+                    error_raised = True
 
-                    logging.info(f"Imported batch of {transaction_count} trips")
+            x10_rec_ort.close()
 
-                    transaction = database.connection().transaction()
-                    transaction_count = 0
+            # load and import line objects
+            line_index = dict()
+            line_direction_index = dict()
 
-            except Exception as ex:
-                transaction.rollback()
+            transaction = database.connection().transaction()
+            transation_count = 0
 
-                if not i >= len(x10_rec_frt.records) - 1:
-                    transaction = database.connection().transaction()
+            x10_rec_lid = self._internal_read_x10_file(input_directory, 'rec_lid.x10')
+            for i, record in enumerate(x10_rec_lid.records):
+                try:
+                    line_id = record['LI_NR']
+                    line_variant_id = record['STR_LI_VAR']
+                    direction = record['LI_RI_NR']
+                    name = record['LI_KUERZEL']
+                    
+                    if 'LinienID' in record:
+                        international_id = record['LinienID']
+                    else:
+                        international_id = None
 
-                logging.exception(ex)
+                    if (line_id, line_variant_id) not in line_direction_index:
+                        line_direction_index[(line_id, line_variant_id)] = direction
 
-        logging.info(f"Imported {len(trip_index)} unique trips for operation day {datetime.now().strftime('%Y%m%d')}")
-    
-        # put every imported file from this import into archive
-        logging.info("Archiving imported files ...")
-        archive_directory_files(input_directory)
+                    if line_id not in line_index:
+                        line_index[line_id] = Line(
+                            line_id=line_id, 
+                            name=name, 
+                            connection=transaction
+                        )
 
-    def _verify(self, input_directory:str) -> None:
+                        transation_count = transation_count + 1
+
+                    if transation_count >= batch_size or i >= len(x10_rec_lid.records) - 1:
+                        transaction.commit()
+
+                        transaction = database.connection().transaction()
+                        transation_count = 0
+
+                except Exception as ex:
+                    transaction.rollback()
+
+                    if not i >= len(x10_rec_lid.records) - 1:
+                        transaction = database.connection().transaction()
+
+                    logging.exception(ex)
+                    error_raised = True
+        
+            x10_rec_lid.close()
+
+            # load timetable information data ...  
+            logging.info('Loading timetable information data ...')
+
+            daytype = None
+            x10_firmenkalender = self._internal_read_x10_file(input_directory, 'firmenkalender.x10')
+            for record in x10_firmenkalender.records:
+                if datetime.now().strftime('%Y%m%d') == str(record['BETRIEBSTAG']):
+                    daytype = record['TAGESART_NR']
+                    break
+
+            x10_firmenkalender.close()
+
+            if daytype == None:
+                raise ValueError(f"No valid daytype number found for {datetime.now().strftime('%Y%m%d')}")
+            
+            logging.info(f"Using daytype number {daytype}")
+
+            # load routes for each line
+            line_route_index = dict()
+            x10_lid_verlauf = self._internal_read_x10_file(input_directory, 'lid_verlauf.x10')
+            for record in x10_lid_verlauf.records:
+                if record['ONR_TYP_NR'] == 1:
+                    line_id = record['LI_NR']
+                    line_variant_id = record['STR_LI_VAR']
+                    stop_nr = record['ORT_NR']
+
+                    if (line_id, line_variant_id) not in line_route_index:
+                        line_route_index[(line_id, line_variant_id)] = list()
+
+                    line_route_index[(line_id, line_variant_id)].append(stop_nr)
+
+            x10_lid_verlauf.close()
+
+            # load time demand types
+            time_demand_type_index = dict()
+            x10_sel_fzt_feld = self._internal_read_x10_file(input_directory, 'sel_fzt_feld.x10')
+            for record in x10_sel_fzt_feld.records:
+                if record['ONR_TYP_NR'] == 1 and record['SEL_ZIEL_TYP'] == 1:
+                    tdt_id = record['FGR_NR']
+                    start_stop_id = record['ORT_NR']
+                    dest_stop_id = record['SEL_ZIEL']
+                    time_demand_seconds = record['SEL_FZT']
+
+                    if tdt_id not in time_demand_type_index:
+                        time_demand_type_index[tdt_id] = dict()
+
+                    if start_stop_id not in time_demand_type_index[tdt_id]:
+                        time_demand_type_index[tdt_id][start_stop_id] = dict()
+
+                    if dest_stop_id not in time_demand_type_index[tdt_id][start_stop_id]:
+                        time_demand_type_index[tdt_id][start_stop_id][dest_stop_id] = dict()
+
+                    time_demand_type_index[tdt_id][start_stop_id][dest_stop_id] = time_demand_seconds
+
+            x10_sel_fzt_feld.close()
+
+            # load stop based waiting time index
+            stop_waiting_time_index = dict()
+
+            x10_ort_hztf = self._internal_read_x10_file(input_directory, 'ort_hztf.x10')
+            for record in x10_ort_hztf.records:
+                if record['ONR_TYP_NR'] == 1:
+                    tdt_id = record['FGR_NR']
+                    stop_id = record['ORT_NR']
+                    waiting_time_seconds = record['HP_HZT']
+
+                    if tdt_id not in stop_waiting_time_index:
+                        stop_waiting_time_index[tdt_id] = dict()
+                        
+                    stop_waiting_time_index[tdt_id][stop_id] = waiting_time_seconds
+
+            x10_ort_hztf.close()
+
+            # load trip based waiting time index
+            trip_waiting_time_index = dict()
+
+            x10_rec_frt_hzt = self._internal_read_x10_file(input_directory, 'rec_frt_hzt.x10')
+            for record in x10_rec_frt_hzt.records:
+                if record['ONR_TYP_NR'] == 1:
+                    trip_id = record['FRT_FID']
+                    stop_id = record['ORT_NR']
+                    waiting_time_seconds = record['FRT_HZT_ZEIT']
+
+                    if trip_id not in trip_waiting_time_index:
+                        trip_waiting_time_index[trip_id] = dict()
+
+                    trip_waiting_time_index[trip_id][stop_id] = waiting_time_seconds
+
+            x10_rec_frt_hzt.close()
+
+            # load and generate trips
+            logging.info('Generating trips ...')
+
+            trip_index = dict()
+
+            transaction = database.connection().transaction()
+            transaction_count = 0
+
+            x10_rec_frt = self._internal_read_x10_file(input_directory, 'rec_frt.x10')
+            for i, record in enumerate(x10_rec_frt.records):
+                try:
+                    if record['TAGESART_NR'] == daytype:
+
+                        trip_id = record['FRT_FID']
+                        line_id = record['LI_NR']
+                        international_id = None
+
+                        _line_variant_id = record['STR_LI_VAR']
+                        _tdt_id = record['FGR_NR']
+                        _last_timestamp = int(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0).timestamp()) + record['FRT_START']
+                        _intermediate_stops = line_route_index[(line_id, _line_variant_id)]
+
+                        direction = line_direction_index[(line_id, _line_variant_id)]
+
+                        trip = Trip(
+                            trip_id=trip_id, 
+                            line=line_index[line_id],
+                            direction=direction,
+                            international_id=international_id,
+                            connection=transaction
+                        )
+
+                        for s in range(0, len(_intermediate_stops)):
+                            stop_id = _intermediate_stops[s]
+                            arrival_timestamp = _last_timestamp
+                            departure_timestamp = arrival_timestamp
+
+                            if _tdt_id in stop_waiting_time_index and stop_id in stop_waiting_time_index[_tdt_id]:
+                                departure_timestamp = departure_timestamp + stop_waiting_time_index[_tdt_id][stop_id]
+
+                            if trip_id in trip_waiting_time_index and stop_id in trip_waiting_time_index[trip_id]:
+                                departure_timestamp = departure_timestamp + trip_waiting_time_index[trip_id][stop_id]
+
+                            StopTime(
+                                stop=stop_index[stop_id],
+                                trip=trip,
+                                arrival_timestamp=arrival_timestamp,
+                                departure_timestamp=departure_timestamp,
+                                sequence=s + 1,
+                                connection=transaction
+                            )
+
+                            if s < len(_intermediate_stops) - 1:
+                                next_stop_id = _intermediate_stops[s + 1]
+
+                                _last_timestamp = departure_timestamp + time_demand_type_index[_tdt_id][stop_id][next_stop_id]
+
+                        trip.headsign = stop_index[_intermediate_stops[-1]].name
+
+                        trip_index[trip.trip_id] = trip
+                        transaction_count = transaction_count + 1
+
+                    if transaction_count >= batch_size or i >= len(x10_rec_frt.records) - 1:
+                        transaction.commit()
+
+                        logging.info(f"Imported batch of {transaction_count} trips")
+
+                        transaction = database.connection().transaction()
+                        transaction_count = 0
+
+                except Exception as ex:
+                    transaction.rollback()
+
+                    if not i >= len(x10_rec_frt.records) - 1:
+                        transaction = database.connection().transaction()
+
+                    logging.exception(ex)
+                    error_raised = True
+
+            logging.info(f"Imported {len(trip_index)} unique trips for operation day {datetime.now().strftime('%Y%m%d')}")
+        
+            # put every imported file from this import into archive
+            logging.info("Archiving imported files ...")
+            archive_directory_files(input_directory, error_raised)
+        
+        except Exception as ex:
+
+            logging.exception(ex)
+            logging.info("Archiving imported files ...")
+            archive_directory_files(input_directory)
+
+    def _verify(self, input_directory:str) -> bool:
         logging.info(f"Verifying files in input directory {input_directory} ...")
 
         if not os.path.isdir(input_directory):
             raise ValueError(f"Input directory {input_directory} is no directory!")
         
         if not directory_contains_files(input_directory):
-            raise ValueError(f"Input directory {input_directory} is empty!")
+            logging.info(f"Input directory {input_directory} is empty!")
+            return False
 
         x10_rec_ort_filename = os.path.join(input_directory, 'rec_ort.x10')
         if not os.path.exists(x10_rec_ort_filename) or not os.path.isfile(x10_rec_ort_filename):
@@ -337,6 +352,8 @@ class DefaultAdapter(BaseAdapter):
         if not os.path.exists(x10_rec_frt_filename) or not os.path.isfile(x10_rec_frt_filename):
             raise FileNotFoundError(f"Required file {x10_rec_frt_filename} not found")
     
+        return True
+
     def _internal_read_x10_file(self, input_directory: str, x10filename: str) -> X10File:
         for entry in os.listdir(input_directory):
             if entry.lower() == x10filename.lower():

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -107,7 +107,7 @@ class DefaultAdapter(BaseAdapter):
                     line_id = record['LI_NR']
                     line_variant_id = record['STR_LI_VAR']
                     direction = record['LI_RI_NR']
-                    name = record['LI_KUERZEL']
+                    name = record['LIDNAME']
                     
                     if 'LinienID' in record:
                         international_id = record['LinienID']

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -255,7 +255,7 @@ class DefaultAdapter(BaseAdapter):
                         # note, that the start timestamp of 'today' is already UTC, but the record['FRT_START'] is in local time of the system which has
                         # exported the data. So we need to convert the whole thing to UTC before proceeding ... see #5 for more information
                         _start_time_local = int(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.utc).timestamp()) + record['FRT_START']
-                        _start_time_utc = int(datetime.fromtimestamp(_start_time_local, tz=pytz.timezone(timezone)).astimezone(pytz.utc).timestamp())
+                        _start_time_utc = int(pytz.timezone(timezone).localize(datetime.fromtimestamp(_start_time_local)).timestamp())
 
                         # create working variables
                         _line_variant_id = record['STR_LI_VAR']

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pytz
 
 from datetime import datetime
 
@@ -247,7 +248,7 @@ class DefaultAdapter(BaseAdapter):
 
                         _line_variant_id = record['STR_LI_VAR']
                         _tdt_id = record['FGR_NR']
-                        _last_timestamp = int(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0).timestamp()) + record['FRT_START']
+                        _last_timestamp = int(datetime.now().astimezone(pytz.timezone('UTC')).replace(hour=0, minute=0, second=0, microsecond=0).timestamp()) + record['FRT_START']
                         _intermediate_stops = line_route_index[(line_id, _line_variant_id)]
 
                         direction = line_direction_index[(line_id, _line_variant_id)]

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -248,7 +248,7 @@ class DefaultAdapter(BaseAdapter):
 
                         _line_variant_id = record['STR_LI_VAR']
                         _tdt_id = record['FGR_NR']
-                        _last_timestamp = int(datetime.now().astimezone(pytz.timezone('UTC')).replace(hour=0, minute=0, second=0, microsecond=0).timestamp()) + record['FRT_START']
+                        _last_timestamp = int(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.utc).timestamp()) + record['FRT_START']
                         _intermediate_stops = line_route_index[(line_id, _line_variant_id)]
 
                         direction = line_direction_index[(line_id, _line_variant_id)]

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -119,7 +119,8 @@ class DefaultAdapter(BaseAdapter):
                     if line_id not in line_index:
                         line_index[line_id] = Line(
                             line_id=line_id, 
-                            name=name, 
+                            name=name,
+                            international_id=international_id, 
                             connection=transaction
                         )
 

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -8,7 +8,6 @@ from vcclib.model import Stop
 from vcclib.model import Line
 from vcclib.model import Trip
 from vcclib.model import StopTime
-from vcclib.filesystem import archive_directory_files
 from vcclib.filesystem import directory_contains_files
 from vcclib.x10 import read_x10_file, X10File
 from vccvdv452import.adapter.base import BaseAdapter
@@ -36,9 +35,6 @@ class DefaultAdapter(BaseAdapter):
         StopTime.deleteMany(where=None)
 
         try:
-            # keep track of every error to archive import files correctly
-            error_raised = False
-
             # load network data ...
             logging.info('Loading network data ...')
 
@@ -89,7 +85,6 @@ class DefaultAdapter(BaseAdapter):
                         transaction = database.connection().transaction()
 
                     logging.exception(ex)
-                    error_raised = True
 
             x10_rec_ort.close()
 
@@ -140,7 +135,6 @@ class DefaultAdapter(BaseAdapter):
                         transaction = database.connection().transaction()
 
                     logging.exception(ex)
-                    error_raised = True
         
             x10_rec_lid.close()
 
@@ -312,19 +306,11 @@ class DefaultAdapter(BaseAdapter):
                         transaction = database.connection().transaction()
 
                     logging.exception(ex)
-                    error_raised = True
 
             logging.info(f"Found {len(trip_index)} unique trips for operation day {datetime.now().strftime('%Y%m%d')}")
         
-            # put every imported file from this import into archive
-            logging.info("Archiving imported files ...")
-            archive_directory_files(input_directory, error_raised)
-        
         except Exception as ex:
-
             logging.exception(ex)
-            logging.info("Archiving imported files ...")
-            archive_directory_files(input_directory)
 
     def _verify(self, input_directory:str) -> bool:
         logging.info(f"Verifying files in input directory {input_directory} ...")

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -83,6 +83,7 @@ class DefaultAdapter(BaseAdapter):
 
                 except Exception as ex:
                     transaction.rollback()
+                    transaction_count = 0
 
                     if not i >= len(x10_rec_ort.records):
                         transaction = database.connection().transaction()
@@ -132,6 +133,7 @@ class DefaultAdapter(BaseAdapter):
 
                 except Exception as ex:
                     transaction.rollback()
+                    transaction_count = 0
 
                     if not i >= len(x10_rec_lid.records) - 1:
                         transaction = database.connection().transaction()
@@ -303,6 +305,7 @@ class DefaultAdapter(BaseAdapter):
 
                 except Exception as ex:
                     transaction.rollback()
+                    transaction_count = 0
 
                     if not i >= len(x10_rec_frt.records) - 1:
                         transaction = database.connection().transaction()
@@ -310,7 +313,7 @@ class DefaultAdapter(BaseAdapter):
                     logging.exception(ex)
                     error_raised = True
 
-            logging.info(f"Imported {len(trip_index)} unique trips for operation day {datetime.now().strftime('%Y%m%d')}")
+            logging.info(f"Found {len(trip_index)} unique trips for operation day {datetime.now().strftime('%Y%m%d')}")
         
             # put every imported file from this import into archive
             logging.info("Archiving imported files ...")


### PR DESCRIPTION
Am VDV452-Import wurden einige Verbesserungen durchgeführt. Darunter:
- Wenn eine Transaktion fehlschlägt, wird der DB-Lock aufgelöst durch ein Rollback. Vorher blieb der DB-Lock aktiv und es konnten keine weiteren Transaktionen gestartet werden.
- Bisher wurden nur Dateien importiert, bei denen die Groß- und Kleinschreibung in der Bezeichnung und im Dateityp übereinstimmte. Nun werden Dateien unabhängig von ihrer Groß- und Kleinschreibung importiert.
- Die Fahrzeiten im VDV452-Export liegen in Lokalzeit vor. Damit VCC korrekt funktioniert, müssen diese aber in UTC gespeichert werden. Die Fahrzeiten werden daher beim Import nach UTC umgewandelt.
- Wenn eine Fahrt an einer Haltestelle endet, wird der departure_timestamp auf None gesetzt. Beim Abfragen aller Abfahrten an einer Station werden die Fahrten dann herausgefiltert.