### PR TITLE
API: Verbesserungen und Log-Upload

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,7 @@ VCC_API_SCHEME=https
 VCC_API_HOSTNAME=localhost
 VCC_API_PORT=9921
 VCC_API_DATA_DIRECTORY=C:/VisualStudioCode/VdvCountCore/Storage/Data
+VCC_API_LOG_DIRECTORY=C:/VisualStudioCode/VdvCountCore/Storage/Logs
 
 VCC_PROXY_SSL_CERT_FILENAME=C:/VisualStudioCode/VdvCountCore/Storage/Certs/ssl-cert.pem
 VCC_PROXY_SSL_CHAIN_FILEMAME=C:/VisualStudioCode/VdvCountCore/Storage/Certs/ssl-chain.pem

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,6 +91,7 @@ services:
       - VCC_API_PORT
     volumes:
       - ${VCC_API_DATA_DIRECTORY}:/data
+      - ${VCC_API_LOG_DIRECTORY}:/logs
     depends_on:
       "vcc-database":
         condition: service_healthy

--- a/src/vccapi/api.py
+++ b/src/vccapi/api.py
@@ -99,6 +99,29 @@ async def results_post(guid, request: Request):
 
     return Response(status_code=200)
 
+@app.post('/logs/post/{device_guid}')
+async def logs_post(device_guid, request: Request):
+    
+    data = await request.body()
+    timestamp = datetime.now().strftime('%Y-%m-%d-%H.%M.%S-%f')
+
+    try:
+        text = data.decode('utf-8')
+
+        if not text.strip():
+            return Response(status_code=400)
+        
+        if not request.headers.get('Content-Type', '').startswith('text/plain'):
+            return Response(status_code=400)
+
+        with open(f"/logs/{timestamp}-{device_guid}.json", 'w+') as file:
+            file.write(text)
+
+    except UnicodeDecodeError:
+        return Response(status_code=400)
+
+    return Response(status_code=200)
+
 @app.get('/system/setup')
 async def system_setup():
     # load data of environment variables and generate setup config

--- a/src/vccapi/api.py
+++ b/src/vccapi/api.py
@@ -49,7 +49,7 @@ async def departures_by_parent_stop_id(parent_stop_id):
                 'sequence': d.sequence
             }
 
-        result.append(obj)
+            result.append(obj)
 
     return result
 

--- a/src/vccapi/api.py
+++ b/src/vccapi/api.py
@@ -33,19 +33,22 @@ async def stops_by_name(lookup_name):
 async def departures_by_parent_stop_id(parent_stop_id):
     parent_stop_id = int(parent_stop_id)
 
+    reference_timestamp = datetime.now().timestamp() - 3600
+
     result = list()
     for d in Stop.departures(parent_stop_id):
-        obj = {
-            'stop_id': d.stop.stop_id,
-            'line': sqlobject2dict(d.trip.line),
-            'trip_id': d.trip.trip_id,
-            'direction': d.trip.direction,
-            'headsign': d.trip.headsign,
-            'international_id': d.trip.international_id,
-            'arrival_timestamp': d.arrival_timestamp,
-            'departure_timestamp': d.departure_timestamp,
-            'sequence': d.sequence
-        }
+        if d.departure_timestamp >= reference_timestamp:
+            obj = {
+                'stop_id': d.stop.stop_id,
+                'line': sqlobject2dict(d.trip.line),
+                'trip_id': d.trip.trip_id,
+                'direction': d.trip.direction,
+                'headsign': d.trip.headsign,
+                'international_id': d.trip.international_id,
+                'arrival_timestamp': d.arrival_timestamp,
+                'departure_timestamp': d.departure_timestamp,
+                'sequence': d.sequence
+            }
 
         result.append(obj)
 

--- a/src/vccapi/api.py
+++ b/src/vccapi/api.py
@@ -114,7 +114,7 @@ async def logs_post(device_guid, request: Request):
         if not request.headers.get('Content-Type', '').startswith('text/plain'):
             return Response(status_code=400)
 
-        with open(f"/logs/{timestamp}-{device_guid}.json", 'w+') as file:
+        with open(f"/logs/{timestamp}-{device_guid}.log", 'w+') as file:
             file.write(text)
 
     except UnicodeDecodeError:

--- a/src/vccapi/api.py
+++ b/src/vccapi/api.py
@@ -83,11 +83,11 @@ async def trips_by_id(trip_id):
 
 @app.get('/masterdata/vehicles')
 async def masterdata_vehicles():
-    return [sqlobject2dict(o) for o in MasterDataVehicle.select()]
+    return [sqlobject2dict(o) for o in MasterDataVehicle.select().orderBy(MasterDataVehicle.q.name)]
 
 @app.get('/masterdata/objectclasses')
 async def masterdata_objectclasses():
-    return [sqlobject2dict(o) for o in MasterDataObjectClass.select()]
+    return [sqlobject2dict(o) for o in MasterDataObjectClass.select().orderBy(MasterDataObjectClass.q.name)]
 
 @app.post('/results/post/{guid}')
 async def results_post(guid, request: Request):

--- a/src/vccapi/api.py
+++ b/src/vccapi/api.py
@@ -10,9 +10,7 @@ from qrcode import QRCode, constants
 
 from vcclib import database
 from vcclib.model import Stop
-from vcclib.model import Line
 from vcclib.model import Trip
-from vcclib.model import StopTime
 from vcclib.model import MasterDataVehicle
 from vcclib.model import MasterDataObjectClass
 
@@ -45,6 +43,7 @@ async def departures_by_parent_stop_id(parent_stop_id):
                 'direction': d.trip.direction,
                 'headsign': d.trip.headsign,
                 'international_id': d.trip.international_id,
+                'operation_day': d.trip.operation_day,
                 'arrival_timestamp': d.arrival_timestamp,
                 'departure_timestamp': d.departure_timestamp,
                 'sequence': d.sequence
@@ -75,6 +74,7 @@ async def trips_by_id(trip_id):
         'direction': trip.direction,
         'headsign': trip.headsign,
         'international_id': trip.international_id,
+        'operation_day': trip.operation_day,
         'next_trip_id': trip.next_trip_id,
         'stop_times': stop_times_result
     }

--- a/src/vcclib/filesystem.py
+++ b/src/vcclib/filesystem.py
@@ -7,6 +7,16 @@ def directory_contains_files(directory: str) -> bool:
     with os.scandir(directory) as entries:
         return any(e.is_file() for e in entries)
     
+
+def file_exists(directory: str, filename: str) -> bool:
+    for entry in os.listdir(directory):
+        if entry.lower() == filename.lower():
+            if os.path.isfile(os.path.join(directory, entry)):
+                return True
+        
+    return False
+
+    
 def archive_directory_files(directory: str, defective: bool = False) -> None:
     if directory_contains_files(directory):
         archive_directory = os.path.join(directory, 'Archive' if not defective else 'Defective', datetime.now().strftime('%Y%m%d%H%M%S'))

--- a/src/vcclib/model.py
+++ b/src/vcclib/model.py
@@ -71,6 +71,7 @@ class Trip(SQLObject):
     direction = IntCol()
     headsign = StringCol(default=None)
     international_id = StringCol(default=None)
+    operation_day = IntCol()
     next_trip_id = IntCol(default=None)
 
     def stop_times(self):

--- a/src/vccmdimport/adapter/csv.py
+++ b/src/vccmdimport/adapter/csv.py
@@ -6,6 +6,7 @@ from vcclib import database
 from vcclib.model import MasterDataVehicle
 from vcclib.model import MasterDataObjectClass
 from vcclib.filesystem import directory_contains_files
+from vcclib.filesystem import file_exists
 from vccmdimport.adapter.base import BaseAdapter
 
 class CsvAdapter(BaseAdapter):
@@ -94,13 +95,11 @@ class CsvAdapter(BaseAdapter):
             logging.info(f"Input directory {input_directory} is empty!")
             return False
 
-        csv_vehicles_filename = os.path.join(input_directory, 'vehicles.csv')
-        if not os.path.exists(csv_vehicles_filename) or not os.path.isfile(csv_vehicles_filename):
-            raise FileNotFoundError(f"Required file {csv_vehicles_filename} not found")
+        if not file_exists(input_directory, 'vehicles.csv'):
+            raise FileNotFoundError(f"Required file vehicles.csv not found")
         
-        csv_object_classes_filename = os.path.join(input_directory, 'object_classes.csv')
-        if not os.path.exists(csv_object_classes_filename) or not os.path.isfile(csv_object_classes_filename):
-            raise FileNotFoundError(f"Required file {csv_object_classes_filename} not found")
+        if not file_exists(input_directory, 'object_classes.csv'):
+            raise FileNotFoundError(f"Required file object_classes.csv not found")
 
         return True
 

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -235,7 +235,8 @@ class DefaultAdapter(BaseAdapter):
             x10_rec_frt_hzt.close()
 
             # load and generate trips
-            logging.info('Generating trips ...')
+            operation_day = int(datetime.now().strftime('%Y%m%d'))
+            logging.info(f"Generating trips for operation day {operation_day} ...")
 
             trip_index = dict()
 
@@ -270,6 +271,7 @@ class DefaultAdapter(BaseAdapter):
                             line=line_index[line_id],
                             direction=direction,
                             international_id=international_id,
+                            operation_day=operation_day,
                             connection=transaction
                         )
 

--- a/src/vccvdv452import/adapter/default.py
+++ b/src/vccvdv452import/adapter/default.py
@@ -10,6 +10,7 @@ from vcclib.model import Line
 from vcclib.model import Trip
 from vcclib.model import StopTime
 from vcclib.filesystem import directory_contains_files
+from vcclib.filesystem import file_exists
 from vcclib.x10 import read_x10_file, X10File
 from vccvdv452import.adapter.base import BaseAdapter
 
@@ -340,25 +341,20 @@ class DefaultAdapter(BaseAdapter):
             logging.info(f"Input directory {input_directory} is empty!")
             return False
 
-        x10_rec_ort_filename = os.path.join(input_directory, 'rec_ort.x10')
-        if not os.path.exists(x10_rec_ort_filename) or not os.path.isfile(x10_rec_ort_filename):
-            raise FileNotFoundError(f"Required file {x10_rec_ort_filename} not found")
+        if not file_exists(input_directory, 'rec_ort.x10'):
+            raise FileNotFoundError(f"Required file rec_ort.x10 not found")
         
-        x10_rec_lid_filename = os.path.join(input_directory, 'rec_lid.x10')
-        if not os.path.exists(x10_rec_lid_filename) or not os.path.isfile(x10_rec_lid_filename):
-            raise FileNotFoundError(f"Required file {x10_rec_lid_filename} not found")
+        if not file_exists(input_directory, 'rec_lid.x10'):
+            raise FileNotFoundError(f"Required file rec_lid.x10 not found")
         
-        x10_lid_verlauf_filename = os.path.join(input_directory, 'lid_verlauf.x10')
-        if not os.path.exists(x10_lid_verlauf_filename) or not os.path.isfile(x10_lid_verlauf_filename):
-            raise FileNotFoundError(f"Required file {x10_lid_verlauf_filename} not found")
+        if not file_exists(input_directory, 'lid_verlauf.x10'):
+            raise FileNotFoundError(f"Required file lid_verlauf.x10 not found")
         
-        x10_sel_fzt_feld_filename = os.path.join(input_directory, 'sel_fzt_feld.x10')
-        if not os.path.exists(x10_sel_fzt_feld_filename) or not os.path.isfile(x10_sel_fzt_feld_filename):
-            raise FileNotFoundError(f"Required file {x10_sel_fzt_feld_filename} not found")
+        if not file_exists(input_directory, 'sel_fzt_feld.x10'):
+            raise FileNotFoundError(f"Required file sel_fzt_feld.x10 not found")
         
-        x10_rec_frt_filename = os.path.join(input_directory, 'rec_frt.x10')
-        if not os.path.exists(x10_rec_frt_filename) or not os.path.isfile(x10_rec_frt_filename):
-            raise FileNotFoundError(f"Required file {x10_rec_frt_filename} not found")
+        if not file_exists(input_directory, 'rec_frt.x10'):
+            raise FileNotFoundError(f"Required file rec_frt.x10 not found")
     
         return True
 


### PR DESCRIPTION
Die API wurde hinsichtlich ihrer Datenlieferung deutlich verbessert:

- Stammdaten (Fahrzeuge und Objektklassen) werden nun immer alphabetisch sortiert ausgegeben
- Über die Abfahrten werden die Fahrten mit einer maximalen Rückschauzeit von 1 Stunde geliefert
- Jedes Trip-/ oder Departure Objekt enthält nun außerdem das Attribut `operation_day` welches den Betriebstag der Fahrt im Format YYYYMMDD zurückgibt
- Der VDV452- und MD-Import wurde so angepasst, dass bei der Verifizierung auch Dateien unabhängig von der Groß- und Kleinschreibung erkannt werden

- Über den Endpunkt `/logs/post/{device_guid}` können fortan Logs hochgeladen werden. Es werden ausschließlich Daten im Body mit Content-Type `text/plain` akzeptiert, die in UTF-8 codiert sind