### PR TITLE
VDV457: Erzeugung von Durchfahrten

### DIFF
--- a/src/vcclib/dataclasses.py
+++ b/src/vcclib/dataclasses.py
@@ -19,6 +19,35 @@ class Stop:
         pass
 
 @dataclass
+class Line:
+    id: int
+    international_id: str
+    name: str
+
+    def __init__(self) -> None:
+        pass
+
+@dataclass
+class StopTime:
+    arrival_time: datetime|None
+    departure_time: datetime|None
+    stop: Stop
+
+    def __init__(self) -> None:
+        pass
+
+@dataclass    
+class Trip:
+    id: int
+    vehicle_id: int
+    direction: int
+    line: Line
+    stop_times: List[StopTime] = field(default_factory=list)
+
+    def __init__(self) -> None:
+        self.stop_times = list()
+
+@dataclass
 class CountingSequence:
     door_id: str
     counting_area_id: str
@@ -108,7 +137,7 @@ class PassengerCountingEvent:
 
         return sum
     
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.stop is not None:
             return f"StopID={self.stop.id}, StopSequence={self.stop.sequence}, Begin={self.begin_timestamp().strftime('%Y-%m-%d %H:%M:%S')}, End={self.end_timestamp().strftime('%Y-%m-%d %H:%M:%S')}, Latitude={self.latitude}, Longitude={self.longitude}, In={self.count_in()}, Out={self.count_out()}"
         else:

--- a/src/vccvdv457export/adapter/base.py
+++ b/src/vccvdv457export/adapter/base.py
@@ -1,6 +1,13 @@
 from abc import ABC
 from abc import abstractmethod
 
+from datetime import datetime
+from datetime import timezone
+
+from vcclib.dataclasses import Trip
+from vcclib.dataclasses import Line
+from vcclib.dataclasses import StopTime
+from vcclib.dataclasses import Stop
 from vcclib.duckdb import DuckDB
 
 class BaseAdapter(ABC):
@@ -11,3 +18,40 @@ class BaseAdapter(ABC):
     @abstractmethod
     def process(self, ddb: DuckDB, output_directory: str) -> None:
         pass
+
+    def load_trip_details(self, ddb: DuckDB, operation_day: int, trip_id: int, vehicle_id: str) -> Trip:
+        trip_details_data: list = ddb.get_trip_details(
+            operation_day,
+            trip_id,
+            vehicle_id
+        )
+
+        line: Line = Line()
+        line.id = trip_details_data[0]['line_id']
+        line.international_id = trip_details_data[0]['line_international_id']
+        line.name = trip_details_data[0]['line_name']
+
+        trip: Trip = Trip()
+        trip.id = trip_details_data[0]['trip_id']
+        trip.direction = trip_details_data[0]['direction']
+        trip.line = line
+
+        for tdd in trip_details_data:
+
+            stop: Stop = Stop()
+            stop.id = tdd['stop_id']
+            stop.parent_id = tdd['stop_parent_id']
+            stop.international_id = tdd['stop_international_id']
+            stop.latitude = tdd['stop_latitude']
+            stop.longitude = tdd['stop_longitude']
+            stop.name = tdd['stop_name']
+            stop.sequence = tdd['stop_sequence']
+
+            stop_time: StopTime = StopTime()
+            stop_time.arrival_time = datetime.fromtimestamp(tdd['nom_arrival_timestamp'], timezone.utc) if tdd['nom_arrival_timestamp'] != 0 else None
+            stop_time.departure_time = datetime.fromtimestamp(tdd['nom_departure_timestamp'], timezone.utc) if tdd['nom_departure_timestamp'] != 0 else None
+            stop_time.stop = stop
+
+            trip.stop_times.append(stop_time)
+
+        return trip

--- a/src/vccvdv457export/adapter/s2/default.py
+++ b/src/vccvdv457export/adapter/s2/default.py
@@ -17,6 +17,7 @@ from vcclib.xml import dict2xml
 
 from vccvdv457export.adapter.base import BaseAdapter
 from vccvdv457export.collector import PassengerCountingEventCollector
+from vccvdv457export.extender import PassengerCountingEventExtender
 
 class DefaultAdapter(BaseAdapter):
 
@@ -87,6 +88,10 @@ class DefaultAdapter(BaseAdapter):
         line_id = trip.line.id
         line_international_id = trip.line.international_id
         line_name = trip.line.name
+
+        # extend PCEs to nominal stops
+        extender: PassengerCountingEventExtender = PassengerCountingEventExtender(trip)
+        passenger_counting_events = extender.extend(passenger_counting_events)
 
         # build results dataset
         result: dict = {

--- a/src/vccvdv457export/adapter/s2/default.py
+++ b/src/vccvdv457export/adapter/s2/default.py
@@ -10,6 +10,7 @@ from typing import Tuple
 from vcclib.common import isoformattime
 from vcclib.dataclasses import PassengerCountingEvent
 from vcclib.dataclasses import CountingSequence
+from vcclib.dataclasses import Trip
 from vcclib.duckdb import DuckDB
 from vcclib.version import version
 from vcclib.xml import dict2xml
@@ -79,17 +80,13 @@ class DefaultAdapter(BaseAdapter):
     def _transform(self, ddb: DuckDB, operation_day: int, trip_id: int, vehicle_id: str, passenger_counting_events: List[PassengerCountingEvent]) -> Tuple[tuple, str]:
 
         # select trip details and obtain basic data
-        trip_details = ddb.get_trip_details(
-            operation_day,
-            trip_id,
-            vehicle_id
-        )
+        trip: Trip = self.load_trip_details(ddb, operation_day, trip_id, vehicle_id)
 
-        direction = trip_details[0]['direction']
+        direction = trip.direction
 
-        line_id = trip_details[0]['line_id']
-        line_international_id = trip_details[0]['line_international_id']
-        line_name = trip_details[0]['line_name']
+        line_id = trip.line.id
+        line_international_id = trip.line.international_id
+        line_name = trip.line.name
 
         # build results dataset
         result: dict = {

--- a/src/vccvdv457export/adapter/s3/default.py
+++ b/src/vccvdv457export/adapter/s3/default.py
@@ -18,6 +18,7 @@ from vcclib.xml import dict2xml
 
 from vccvdv457export.adapter.base import BaseAdapter
 from vccvdv457export.collector import PassengerCountingEventCollector
+from vccvdv457export.extender import PassengerCountingEventExtender
 
 class DefaultAdapter(BaseAdapter):
 
@@ -94,6 +95,10 @@ class DefaultAdapter(BaseAdapter):
         line_id = trip.line.id
         line_international_id = trip.line.international_id
         line_name = trip.line.name
+
+        # extend PCEs to nominal stops
+        extender: PassengerCountingEventExtender = PassengerCountingEventExtender(trip)
+        passenger_counting_events = extender.extend(passenger_counting_events)
 
         # build results dataset
         result: dict = {

--- a/src/vccvdv457export/extender.py
+++ b/src/vccvdv457export/extender.py
@@ -1,11 +1,17 @@
+import logging
 
 from typing import List
+
+from datetime import datetime
+from datetime import timedelta
 
 from vcclib.dataclasses import Trip
 from vcclib.dataclasses import PassengerCountingEvent
 from vcclib.dataclasses import CountingSequence
 
 class PassengerCountingEventExtender:
+
+    MAXIMUM_TEMPORAL_SEQUENCE_DELTA_MINUTES = 30
 
     def __init__(self, trip: Trip) -> None:
         self._trip = trip
@@ -43,4 +49,46 @@ class PassengerCountingEventExtender:
         # sort result by stop sequence
         result.sort(key=lambda p: p.stop.sequence if p.stop is not None else p.after_stop_sequence)
 
+        # shift temporal sequence of added PCE
+        logging.info(f"Generating temporal sequence for {len(result)} PCE ...")
+        result = self._ensure_temporal_sequence(result)
+
         return result
+    
+    def _ensure_temporal_sequence(self, passenger_counting_events: List[PassengerCountingEvent], min_delta_minutes: float = 0.166667) -> List[PassengerCountingEvent]:
+
+        passenger_counting_events = passenger_counting_events.copy()
+        for i in range(1, len(passenger_counting_events)):
+            previous_pce: PassengerCountingEvent = passenger_counting_events[i - 1]
+            current_pce: PassengerCountingEvent = passenger_counting_events[i]
+
+            if current_pce.begin_timestamp() < previous_pce.end_timestamp():
+                absolute_delta_minutes: float = self._get_absolute_delta_minutes(current_pce.begin_timestamp(), previous_pce.end_timestamp())
+                if absolute_delta_minutes <= self.MAXIMUM_TEMPORAL_SEQUENCE_DELTA_MINUTES:
+                    absolute_delta_minutes += min_delta_minutes
+                    
+                    if self._is_fixed_pce(current_pce):
+                        if not self._is_fixed_pce(previous_pce):
+                            self._shift_pce(previous_pce, timedelta(minutes=-max(min_delta_minutes, absolute_delta_minutes)))
+                    else:
+                        self._shift_pce(current_pce, timedelta(minutes=max(min_delta_minutes, absolute_delta_minutes)))
+                else:
+                    logging.warning(f"Ensuring temporal sequence between PCE [{i - 1}] and PCE [{i}] would require a shift of {absolute_delta_minutes}min, maximum is {self.MAXIMUM_TEMPORAL_SEQUENCE_DELTA_MINUTES}min")
+
+        return passenger_counting_events
+
+    def _get_absolute_delta_minutes(self, dt1: datetime, dt2: datetime) -> float:
+        delta: timedelta = dt2 - dt1
+
+        minutes: float = delta.total_seconds() / 60
+        return abs(minutes)
+    
+    def _is_fixed_pce(self, passenger_counting_event: PassengerCountingEvent) -> bool:
+        return len([cs for cs in passenger_counting_event.counting_sequences if cs.door_id != '0']) > 0
+    
+    def _shift_pce(self, passenger_counting_event: PassengerCountingEvent, delta: timedelta) -> None:
+        timestamp: datetime = passenger_counting_event.counting_sequences[0].begin_timestamp + delta
+        
+        passenger_counting_event.counting_sequences[0].begin_timestamp = timestamp
+        passenger_counting_event.counting_sequences[0].end_timestamp = timestamp
+

--- a/src/vccvdv457export/extender.py
+++ b/src/vccvdv457export/extender.py
@@ -1,0 +1,46 @@
+
+from typing import List
+
+from vcclib.dataclasses import Trip
+from vcclib.dataclasses import PassengerCountingEvent
+from vcclib.dataclasses import CountingSequence
+
+class PassengerCountingEventExtender:
+
+    def __init__(self, trip: Trip) -> None:
+        self._trip = trip
+
+    def extend(self, passenger_counting_events: List[PassengerCountingEvent]) -> List[PassengerCountingEvent]:
+
+        result: List[PassengerCountingEvent] = list()
+        result.extend(passenger_counting_events)
+
+        for stop_time in self._trip.stop_times:
+
+            # check if there's no PCE for this stop
+            existing_passenger_counting_events: List[PassengerCountingEvent] = [pce for pce in passenger_counting_events if pce.stop is not None and pce.stop.id == stop_time.stop.id and pce.stop.sequence == stop_time.stop.sequence]
+            if len(existing_passenger_counting_events) == 0:
+
+                # generate empty PCE for this stop
+                cs: CountingSequence = CountingSequence()
+                cs.begin_timestamp = stop_time.departure_time if stop_time.departure_time is not None else stop_time.arrival_time
+                cs.end_timestamp = stop_time.departure_time if stop_time.departure_time is not None else stop_time.arrival_time
+                cs.counting_area_id = '1'
+                cs.door_id = '0'
+                cs.object_class = 'Adult'
+                cs.count_in = 0
+                cs.count_out = 0
+
+                pce: PassengerCountingEvent = PassengerCountingEvent()
+                pce.latitude = stop_time.stop.latitude
+                pce.longitude = stop_time.stop.longitude
+                pce.stop = stop_time.stop
+
+                pce.counting_sequences.append(cs)
+
+                result.append(pce)
+
+        # sort result by stop sequence
+        result.sort(key=lambda p: p.stop.sequence if p.stop is not None else p.after_stop_sequence)
+
+        return result

--- a/src/vccvdv457export/resources/sql/select_trip_details.sql
+++ b/src/vccvdv457export/resources/sql/select_trip_details.sql
@@ -33,9 +33,9 @@ SELECT operation_day,
        line_international_id,
        line_name
 FROM counted_stops
-WHERE operation_day = 20250521
-    AND trip_id = 4367
-    AND vehicle_id = 'PF-ER-181'
+WHERE operation_day = ?
+    AND trip_id = ?
+    AND vehicle_id = ?
 GROUP BY
 	operation_day,
 	trip_id,

--- a/src/vccvdv457export/resources/sql/select_trip_details.sql
+++ b/src/vccvdv457export/resources/sql/select_trip_details.sql
@@ -1,7 +1,6 @@
 WITH expanded_trip AS
     (SELECT operation_day,
             trip_id,
-            device_id,
             vehicle_id,
             counted_stop_times,
             direction,
@@ -10,7 +9,6 @@ WITH expanded_trip AS
      counted_stops AS
     (SELECT operation_day,
             trip_id,
-            device_id,
             vehicle_id,
             direction,
             line_id,
@@ -20,7 +18,6 @@ WITH expanded_trip AS
      FROM expanded_trip)
 SELECT operation_day,
        trip_id,
-       device_id,
        vehicle_id,
        counted_stop.arrival_timestamp AS nom_arrival_timestamp,
        counted_stop.departure_timestamp AS nom_departure_timestamp,
@@ -36,6 +33,15 @@ SELECT operation_day,
        line_international_id,
        line_name
 FROM counted_stops
-WHERE operation_day = ?
-    AND trip_id = ?
-    AND vehicle_id = ?
+WHERE operation_day = 20250521
+    AND trip_id = 4367
+    AND vehicle_id = 'PF-ER-181'
+GROUP BY
+	operation_day,
+	trip_id,
+	vehicle_id,
+	counted_stop,
+	direction,
+	line_id,
+	line_international_id,
+	line_name


### PR DESCRIPTION
Der Extender wurde entsprechend implementiert. Er erzeugt nun "leere" PCE, um die Durchfahrten für alle Haltestellen aus dem Soll zu erzeugen, die nicht aktiv gezählt wurden. Die PCE sind erkennbar am Vorhandensein von Tür-ID 0, sowie Start- == End-Zeitstempel. Als Zeitpunkt wird jeweils die Soll-Abfahrtszeit gewählt. Um die zeitliche Reihenfolge sicherzustellen, werden Soll-Abfahrten ggf. um 10s (hard coded) weiter nach hinten geschoben, bis wieder sich die PCE nicht mehr überlappen.