### PR TITLE
VDV457: Zusammenlegen von Zwischenhalten und Regelhalten

### DIFF
--- a/src/vcclib/dataclasses.py
+++ b/src/vcclib/dataclasses.py
@@ -42,6 +42,7 @@ class Trip:
     vehicle_id: int
     direction: int
     line: Line
+    international_id: str|None = None
     stop_times: List[StopTime] = field(default_factory=list)
 
     def __init__(self) -> None:

--- a/src/vccvdv457export/adapter/base.py
+++ b/src/vccvdv457export/adapter/base.py
@@ -33,6 +33,7 @@ class BaseAdapter(ABC):
 
         trip: Trip = Trip()
         trip.id = trip_details_data[0]['trip_id']
+        trip.international_id = trip_details_data[0]['trip_international_id']
         trip.direction = trip_details_data[0]['direction']
         trip.line = line
 

--- a/src/vccvdv457export/adapter/s2/default.py
+++ b/src/vccvdv457export/adapter/s2/default.py
@@ -172,12 +172,14 @@ class DefaultAdapter(BaseAdapter):
                         'Value': 'true'
                     }
                 }
-            else:
+            # do not generate StopInformation at all, if there's no stop available
+            # validation agains XSD fails in that case
+            """else:
                 pce_xml['StopInformation'] = {
                     'PassengerRelated': {
                         'Value': 'true'
                     }
-                }
+                }"""
                 
             # GPS position
             pce_xml['GNSS'] = {

--- a/src/vccvdv457export/collector.py
+++ b/src/vccvdv457export/collector.py
@@ -74,7 +74,7 @@ class PassengerCountingEventCollector:
                     stop: Stop = self._extract_stop(row)
                     pce.stop = stop
                 else:
-                    pce.after_stop_sequence = row['after_stop_sequence']
+                    pce.after_stop_sequence = row['pce_after_stop_sequence']
 
         # add final PCE to results
         if pce is not None:

--- a/src/vccvdv457export/collector.py
+++ b/src/vccvdv457export/collector.py
@@ -40,7 +40,7 @@ class PassengerCountingEventCollector:
                 logging.warning(f"{p + 1}. PCE overlaps {p}. PCE in timestamp and remains to different stops")
 
     def get_passenger_counting_events(self) -> List[PassengerCountingEvent]:
-        return self._passenger_counting_events
+        return sorted(self._passenger_counting_events, key=lambda p: p.end_timestamp())
     
     def _extract_passenger_counting_events(self, data: List[tuple]) -> List[PassengerCountingEvent]:
         results: List[PassengerCountingEvent] = list()

--- a/src/vccvdv457export/extender.py
+++ b/src/vccvdv457export/extender.py
@@ -53,7 +53,7 @@ class PassengerCountingEventExtender:
         logging.info(f"Generating temporal sequence for {len(result)} PCE ...")
         result = self._ensure_temporal_sequence(result)
 
-        return result
+        return sorted(result, key=lambda p: p.end_timestamp())
     
     def _ensure_temporal_sequence(self, passenger_counting_events: List[PassengerCountingEvent], min_delta_minutes: float = 0.166667) -> List[PassengerCountingEvent]:
 

--- a/src/vccvdv457export/resources/sql/select_trip_details.sql
+++ b/src/vccvdv457export/resources/sql/select_trip_details.sql
@@ -1,6 +1,7 @@
 WITH expanded_trip AS
     (SELECT operation_day,
             trip_id,
+            international_id AS trip_international_id,
             vehicle_id,
             counted_stop_times,
             direction,
@@ -9,6 +10,7 @@ WITH expanded_trip AS
      counted_stops AS
     (SELECT operation_day,
             trip_id,
+            international_id AS trip_international_id,
             vehicle_id,
             direction,
             line_id,
@@ -18,6 +20,7 @@ WITH expanded_trip AS
      FROM expanded_trip)
 SELECT operation_day,
        trip_id,
+       trip_international_id,
        vehicle_id,
        counted_stop.arrival_timestamp AS nom_arrival_timestamp,
        counted_stop.departure_timestamp AS nom_departure_timestamp,
@@ -39,9 +42,12 @@ WHERE operation_day = ?
 GROUP BY
 	operation_day,
 	trip_id,
+	trip_international_id,
 	vehicle_id,
 	counted_stop,
 	direction,
 	line_id,
 	line_international_id,
 	line_name
+ORDER BY
+	counted_stop.sequence


### PR DESCRIPTION
Der VDV457-3 Export wurde dahingehend angepasst, dass aufgezeichnete Zwischenhalte der jeweils vorhergehenden Haltestelle zugeordnet werden. Im VDV457-2 Export werden die Zwischenhalte weiterhin ganz normal mit ihrer GPS-Position und Zeitstempel exportiert.