### PR TITLE
VDV457: Anpassung zur Behandlung von Durchfahrten mit darauffolgenden Zwischenhalten

### DIFF
--- a/src/vcclib/dataclasses.py
+++ b/src/vcclib/dataclasses.py
@@ -138,6 +138,13 @@ class PassengerCountingEvent:
 
         return sum
     
+    def is_run_through(self) -> bool:
+        counting_sequence: CountingSequence = self.counting_sequences[0] if len(self.counting_sequences) > 0 else None
+        if counting_sequence is not None:
+            return counting_sequence.door_id == '0' and counting_sequence.begin_timestamp == counting_sequence.end_timestamp
+        
+        return False
+    
     def __repr__(self) -> str:
         if self.stop is not None:
             return f"StopID={self.stop.id}, StopSequence={self.stop.sequence}, Begin={self.begin_timestamp().strftime('%Y-%m-%d %H:%M:%S')}, End={self.end_timestamp().strftime('%Y-%m-%d %H:%M:%S')}, Latitude={self.latitude}, Longitude={self.longitude}, In={self.count_in()}, Out={self.count_out()}"

--- a/src/vccvdv457export/adapter/s3/default.py
+++ b/src/vccvdv457export/adapter/s3/default.py
@@ -276,6 +276,11 @@ class DefaultAdapter(BaseAdapter):
             if len(matching_pces) == 1:
                 matched_passenger_counting_events.append(matching_pces[0])
             elif len(matching_pces) > 1:
+                # filter on all real (not run-through!) PCEs 
+                # see #28 for more information
+                matching_pces = [pce for pce in matching_pces if not pce.is_run_through()]
+
+                # then map all remaining PCEs together to one
                 primary_pce: PassengerCountingEvent = matching_pces[0]
                 for i in range(1, len(matching_pces)):
                     primary_pce.combine(matching_pces[i])


### PR DESCRIPTION
Der VDV457-3 Export wurde so angepasst, dass bei einer aufgezeichneten Durchfahrt und einem darauffolgenden Zwischenhalt beim Zusammenführen beider Halte zur regulären Haltestelle die Durchfahrt verworfen und der Zwischenhalt (oder mehrere Zwischenhalte) übernommen werden.