### PR TITLE
VDV457: Zwischenhalte mit Zuordnung zur Folgehaltestelle

### DIFF
--- a/src/vccvdv457export/adapter/s3/default.py
+++ b/src/vccvdv457export/adapter/s3/default.py
@@ -257,12 +257,13 @@ class DefaultAdapter(BaseAdapter):
 
         logging.info(f"Updating unmatched PCEs ...")
 
-        # 1. Update all PCEs with after_stop_sequence != -1 to the corresponding stop
+        # 1. Update all PCEs with after_stop_sequence != -1 to the NEXT stop
+        # see #30 for details
         for pce in passenger_counting_events:
             if pce.after_stop_sequence != -1:
                 stop_sequence: int = pce.after_stop_sequence
                 if len(trip.stop_times) > stop_sequence:
-                    stop: Stop = trip.stop_times[stop_sequence - 1].stop
+                    stop: Stop = trip.stop_times[stop_sequence].stop
 
                     pce.after_stop_sequence = -1
                     pce.stop = stop


### PR DESCRIPTION
Die Daten aus Zwischenhalten werden nun der folgenden Haltestelle, nicht mehr wie bisher der vorhergehenden Haltestelle zugeordnet. Aus diesem Grund dürfen nach der letzten Haltestelle keine Zwischenhalte mehr erfasst werden, weil ansonsten die Zuordnung nicht möglich ist.