### PR TITLE
BugFix: Angabe öffentlicher API URL

### DIFF
--- a/default.env
+++ b/default.env
@@ -7,6 +7,7 @@ VCC_API_SCHEME=https
 VCC_API_HOSTNAME=localhost
 VCC_API_PORT=9921
 VCC_API_SSL_PORT=9922
+VCC_API_PUBLIC_BASE_URL=https://localhost:9921/
 VCC_API_DATA_DIRECTORY=C:/VisualStudioCode/VdvCountCore/Storage/Data
 VCC_API_LOG_DIRECTORY=C:/VisualStudioCode/VdvCountCore/Storage/Logs
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -90,6 +90,7 @@ services:
       - VCC_API_SCHEME
       - VCC_API_HOSTNAME
       - VCC_API_PORT
+      - VCC_API_PUBLIC_BASE_URL
     volumes:
       - ./src/resources:/etc/resources
       - ${VCC_API_DATA_DIRECTORY}:/data

--- a/src/vccapi/api.py
+++ b/src/vccapi/api.py
@@ -148,6 +148,8 @@ async def system_setup():
     api_hostname = os.getenv('VCC_API_HOSTNAME', 'localhost')
     api_port = os.getenv('VCC_API_PORT', '443')
 
+    api_public_base_url: str = os.getenv('VCC_API_PUBLIC_BASE_URL', None)
+
     vcc_username = os.getenv('VCC_USERNAME', None)
     vcc_password = os.getenv('VCC_PASSWORD', None)
 
@@ -155,7 +157,11 @@ async def system_setup():
         logging.error('Either environment variable VCC_USERNAME or VCC_PASSWORD not configured!')
         return Response(status_code=500)
     
-    setup_config = f"{api_scheme}://{vcc_username}:{vcc_password}@{api_hostname}:{api_port}/"
+    if api_public_base_url is not None:
+        api_scheme, api_base_url = api_public_base_url.split('://')
+        setup_config = f"{api_scheme}://{vcc_username}:{vcc_password}@{api_base_url}"
+    else:
+        setup_config = f"{api_scheme}://{vcc_username}:{vcc_password}@{api_hostname}:{api_port}/"
     
     # generate QR code response
     qr = QRCode(


### PR DESCRIPTION
Beim Erzeugen des Setup-Codes in der API versucht die API die Zugangsdaten (den Endpunkt) aus der bisherigen Config zu ermitteln. Wenn die API aber hinter einem weiteren ReverseProxy bzw. LoadBalancer o.Ä. läuft, wird sie im Normalfall auf HTTP und Port 80 beschränkt und kennt auch über die bisherige Konfiguration nur ihre lokale URL auf dem Host, nicht aber die URL, über die die API später nach außen erreichbar ist. 

Zu diesem Zweck wurde die ENV `VCC_API_PUBLIC_BASE_URL` eingeführt: Mit dieser kann nun eine öffentliche BaseURL für die API vorgegeben werden. Die Zugangsdaten werden in der API in die URL eingefügt. Wenn die Variable nicht angegeben wird, wird das bisherige Verfahren zur Erzeugung der öffentlichen URL angewandt.