### PR TITLE
VVS: Import des Liniennamens aus LI_KUERZEL

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,14 @@
             "group": "build",
             "problemMatcher": [],
             "isBackground": true
+        },
+        {
+            "label": "vccvdv452import-dev",
+            "type": "shell",
+            "command": "docker compose -f docker-compose.yaml -f docker-compose.dev.yaml --env-file dev.env up -d --build vcc-vdv452-import",
+            "group": "build",
+            "problemMatcher": [],
+            "isBackground": true
         }
     ]
 }

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,4 +1,11 @@
 services:
+  vcc-vdv452-import:
+    entrypoint: >
+      sh -c "
+        pip install debugpy && PYTHONPATH=src python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m vccvdv452import main
+      "
+    ports:
+      - "5678:5678"
   vcc-vdv457-export:
     entrypoint: >
       sh -c "

--- a/src/vccvdv452import/adapter/vvs.py
+++ b/src/vccvdv452import/adapter/vvs.py
@@ -1,13 +1,68 @@
+import logging
+
+from typing import Tuple
+
+from vcclib import database
+from vcclib.model import Line
 from vccvdv452import.adapter.default import DefaultAdapter
 
 
 class VvsAdapter(DefaultAdapter):
-    
-    def process(self, input_directory: str) -> None:
-        super().process(input_directory)
 
-    def _convert_coordinate(self, input: float|str) -> float:
+    def _extract_line_data(self, input_directory: str, batch_size: int) -> Tuple[dict, dict]:
+        line_index: dict = dict()
+        line_direction_index: dict = dict()
+
+        transaction = database.connection().transaction()
+        transation_count = 0
+
+        x10_rec_lid = self._internal_read_x10_file(input_directory, 'rec_lid.x10')
+        for i, record in enumerate(x10_rec_lid.records):
+            try:
+                line_id = record['LI_NR']
+                line_variant_id = record['STR_LI_VAR']
+                direction = record['LI_RI_NR']
+                name = record['LI_KUERZEL']
+                
+                if 'LinienID' in record:
+                    international_id = record['LinienID']
+                else:
+                    international_id = None
+
+                if (line_id, line_variant_id) not in line_direction_index:
+                    line_direction_index[(line_id, line_variant_id)] = direction
+
+                if line_id not in line_index:
+                    line_index[line_id] = Line(
+                        line_id=line_id, 
+                        name=name,
+                        international_id=international_id, 
+                        connection=transaction
+                    )
+
+                    transation_count = transation_count + 1
+
+                if transation_count >= batch_size or i >= len(x10_rec_lid.records) - 1:
+                    transaction.commit()
+
+                    transaction = database.connection().transaction()
+                    transation_count = 0
+
+            except Exception as ex:
+                transaction.rollback()
+                transaction_count = 0
+
+                if not i >= len(x10_rec_lid.records) - 1:
+                    transaction = database.connection().transaction()
+
+                logging.exception(ex)
+    
+        x10_rec_lid.close()
+
+        return line_index, line_direction_index
+
+    """def _convert_coordinate(self, input: float|str) -> float:
         if type(input) == str:
             input = float(input)
             
-        return input / 10000000.0
+        return input / 10000000.0"""


### PR DESCRIPTION
Der VVS-Adapter wurde so angepasst, dass beim VDV452-Import die Linienbezeichnung nun aus dem Feld `LI_KUERZEL` geladen wird, statt `LIDNAME`.

Damit die Änderung wirksam wird, muss die Variable `VCC_VDV452_ADAPTER_TYPE` auf den Wert "vvs" gesetzt werden.