### PR TITLE
HotFix: Polars Dependency mit LTS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ mdimport = [
 vdv457export = [
     "duckdb",
     "lxml",
-    "polars",
+    "polars-lts-cpu",
     "pyarrow"
 ]
 


### PR DESCRIPTION
Die Dependency `polars` aus dem VDV457-Export verträgt sich nicht mit allen CPUs. Stattdessen wurde nun die Dependency `polars-lts-cpu` verwendet, bei der die Probleme nicht auftreten.

Beim Update muss nichts weiter beachtet werden.