### PR TITLE
API: Erweiterung für die Entgegennahme von Wegpunkten

### DIFF
--- a/src/resources/json/schema.json
+++ b/src/resources/json/schema.json
@@ -191,6 +191,12 @@
           }
         ]
       },
+      "vca_version": {
+        "type": "string"
+      },
+      "vehicle_id": {
+        "type": "string"
+      },
       "way_points": {
         "type": "array",
         "items": [
@@ -214,12 +220,6 @@
             ]
           }
         ]
-      },
-      "vca_version": {
-        "type": "string"
-      },
-      "vehicle_id": {
-        "type": "string"
       },
       "direction": {
         "type": "integer"

--- a/src/resources/json/schema.json
+++ b/src/resources/json/schema.json
@@ -191,6 +191,30 @@
           }
         ]
       },
+      "way_points": {
+        "type": "array",
+        "items": [
+          {
+            "type": "object",
+            "properties": {
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              },
+              "timestamp": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "latitude",
+              "longitude",
+              "timestamp"
+            ]
+          }
+        ]
+      },
       "vca_version": {
         "type": "string"
       },


### PR DESCRIPTION
Die API wurde so erweitert, dass sie nun auch Zählfahrten mit Wegpunkten entgegennehmen kann. Die Wegpunkte sind dabei optional, führen aber höchstwahrscheinlich zu Schwierigkeiten beim Laden der Zähldaten in die DDB, da dort dann eine Spalte zu viel enthalten ist, welche dann in den JSON-Daten fehlt.