### PR TITLE
API: Beschränkung der Fahrten auf Starthaltestellen

### DIFF
--- a/default.env
+++ b/default.env
@@ -10,6 +10,7 @@ VCC_API_SSL_PORT=9922
 VCC_API_PUBLIC_BASE_URL=https://localhost:9921/
 VCC_API_DATA_DIRECTORY=C:/VisualStudioCode/VdvCountCore/Storage/Data
 VCC_API_LOG_DIRECTORY=C:/VisualStudioCode/VdvCountCore/Storage/Logs
+VCC_API_ONLY_STARTING_TRIPS=false
 
 VCC_PROXY_SSL_ACTIVE=true
 VCC_PROXY_SSL_CERT_FILENAME=C:/VisualStudioCode/VdvCountCore/Storage/Certs/ssl-cert.pem

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,6 +91,7 @@ services:
       - VCC_API_HOSTNAME
       - VCC_API_PORT
       - VCC_API_PUBLIC_BASE_URL
+      - VCC_API_ONLY_STARTING_TRIPS
     volumes:
       - ./src/resources:/etc/resources
       - ${VCC_API_DATA_DIRECTORY}:/data

--- a/src/vccapi/api.py
+++ b/src/vccapi/api.py
@@ -11,6 +11,7 @@ from qrcode import QRCode, constants
 
 from vcclib import database
 from vcclib.common import is_debug
+from vcclib.common import is_set
 from vcclib.model import Stop
 from vcclib.model import Trip
 from vcclib.model import MasterDataVehicle
@@ -30,16 +31,16 @@ app = FastAPI()
 # define ressouces and routes
 @app.get('/stops/byLookupName/{lookup_name}')
 async def stops_by_name(lookup_name):
-    return Stop.lookup(lookup_name)
+    return Stop.lookup(lookup_name, is_set('VCC_API_ONLY_STARTING_TRIPS'))
 
 @app.get('/departures/byParentStopId/{parent_stop_id}')
 async def departures_by_parent_stop_id(parent_stop_id):
     parent_stop_id = int(parent_stop_id)
 
     reference_timestamp = datetime.now().timestamp() - 3600
-
+    
     result = list()
-    for d in Stop.departures(parent_stop_id):
+    for d in Stop.departures(parent_stop_id, is_set('VCC_API_ONLY_STARTING_TRIPS')):
         if d.departure_timestamp >= reference_timestamp:
             obj = {
                 'stop_id': d.stop.stop_id,

--- a/src/vcclib/common.py
+++ b/src/vcclib/common.py
@@ -2,8 +2,12 @@ import os
 
 from datetime import datetime
 
+def is_set(variable_name: str) -> bool:
+    variable_value: str = os.getenv(variable_name, 'false').lower().strip()
+    return variable_value == 'true' or variable_value == '1'
+
 def is_debug() -> bool:
-    return os.getenv('VCC_DEBUG', 'false').lower() == 'true' or os.getenv('VCC_DEBUG', 'false') == '1'
+    return is_set('VCC_DEBUG')
 
 def isoformattime(dt: datetime) -> str:
     iso: str = dt.strftime('%H:%M:%S%z')


### PR DESCRIPTION
Die API wurde so angepasst, dass nur noch Haltestellen ausgegeben werden, an denen Fahrten beginnen. Ebenso wurde die API dahingehend angepasst, dass je Haltestelle nur noch Fahrten ausgegeben werden, welche auch an der entspr. Haltestelle beginnen.

Damit diese Funktion aktiviert wird, muss die ENV `VCC_API_ONLY_STARTING_TRIPS` auf `true` gesetzt werden. Ansonsten bleibt das Verhalten der API gleich.