### PR TITLE
VDV457: BugFix und kleine Verbesserungen

### DIFF
--- a/src/vcclib/dataclasses.py
+++ b/src/vcclib/dataclasses.py
@@ -57,6 +57,7 @@ class CountingSequence:
     end_timestamp: datetime
     count_in: int = 0
     count_out: int = 0
+    device_id: str|None = None
 
     def __init__(self) -> None:
         pass
@@ -79,9 +80,8 @@ class PassengerCountingEvent:
             # instead throw an exception if the door ID already exists
             existing_cs: CountingSequence = next((cs for cs in self.counting_sequences if cs.counting_area_id == counting_sequence.counting_area_id and cs.door_id == counting_sequence.door_id and cs.object_class == counting_sequence.object_class), None)
             if existing_cs is not None:
-                if fail_on_existing_door_id and counting_sequence.door_id != '0':
-                    pass
-                    #raise ValueError(f"CountingSequence with DoorID {counting_sequence.door_id} already exists for CountingAreaID {counting_sequence.counting_area_id} and ObjectClass {counting_sequence.object_class} at StopID {self.stop.id} and StopSequence {self.stop.sequence}.")
+                if fail_on_existing_door_id and counting_sequence.door_id != '0' and self.device_id != pce.device_id:
+                    raise ValueError(f"CountingSequence with DoorID {counting_sequence.door_id} already exists for CountingAreaID {counting_sequence.counting_area_id} and ObjectClass {counting_sequence.object_class} at StopID {self.stop.id} and StopSequence {self.stop.sequence}, recorded by DeviceID {self.device_id} and DeviceID {pce.device_id}")
             
                 existing_cs.count_in += counting_sequence.count_in
                 existing_cs.count_out += counting_sequence.count_out

--- a/src/vcclib/dataclasses.py
+++ b/src/vcclib/dataclasses.py
@@ -68,6 +68,7 @@ class PassengerCountingEvent:
     after_stop_sequence: int = -1
     stop: Stop|None = None
     counting_sequences: List[CountingSequence] = field(default_factory=list)
+    device_id: str|None = None
 
     def __init__(self) -> None:
         self.counting_sequences = list()

--- a/src/vcclib/dataclasses.py
+++ b/src/vcclib/dataclasses.py
@@ -97,7 +97,7 @@ class PassengerCountingEvent:
         time_intersection: bool = False
 
         if consider_time:
-            if self.begin_timestamp() <= pce.begin_timestamp() <= self.end_timestamp():
+            if self.begin_timestamp() <= pce.end_timestamp() and pce.begin_timestamp() <= self.end_timestamp():
                 time_intersection = True
         else:
             time_intersection = True

--- a/src/vcclib/dataclasses.py
+++ b/src/vcclib/dataclasses.py
@@ -96,7 +96,7 @@ class PassengerCountingEvent:
         # check if time of PCEs are intersecting
         time_intersection: bool = False
 
-        if consider_time:
+        if consider_time and not (self.is_run_through() and pce.is_run_through()):
             if self.begin_timestamp() <= pce.end_timestamp() and pce.begin_timestamp() <= self.end_timestamp():
                 time_intersection = True
         else:

--- a/src/vcclib/dataclasses.py
+++ b/src/vcclib/dataclasses.py
@@ -74,17 +74,18 @@ class PassengerCountingEvent:
     def __init__(self) -> None:
         self.counting_sequences = list()
 
-    def combine(self, pce: 'PassengerCountingEvent', fail_on_existing_door_id:bool = True) -> None:
+    def combine(self, pce: 'PassengerCountingEvent', fail_on_existing_door_id_of_different_device:bool = True) -> None:
         for counting_sequence in pce.counting_sequences:
-            # see #48/49, don't respect the door ID in first instance
-            # instead throw an exception if the door ID already exists
-            existing_cs: CountingSequence = next((cs for cs in self.counting_sequences if cs.counting_area_id == counting_sequence.counting_area_id and cs.door_id == counting_sequence.door_id and cs.object_class == counting_sequence.object_class), None)
-            if existing_cs is not None:
-                if fail_on_existing_door_id and counting_sequence.door_id != '0' and self.device_id != pce.device_id:
+            # see #48/49: check whether the same door ID has been delivered by a different device yet
+            # if so, throw an exception if fail_on_existing_door_id is True
+            existing_counting_seqeunce: CountingSequence = next((cs for cs in self.counting_sequences if cs.counting_area_id == counting_sequence.counting_area_id and cs.door_id == counting_sequence.door_id and cs.object_class == counting_sequence.object_class), None)
+            if existing_counting_seqeunce is not None:
+                #"""fail_on_existing_door_id_of_different_device and"""
+                if counting_sequence.door_id != '0' and existing_counting_seqeunce.device_id != counting_sequence.device_id:
                     raise ValueError(f"CountingSequence with DoorID {counting_sequence.door_id} already exists for CountingAreaID {counting_sequence.counting_area_id} and ObjectClass {counting_sequence.object_class} at StopID {self.stop.id} and StopSequence {self.stop.sequence}, recorded by DeviceID {self.device_id} and DeviceID {pce.device_id}")
             
-                existing_cs.count_in += counting_sequence.count_in
-                existing_cs.count_out += counting_sequence.count_out
+                existing_counting_seqeunce.count_in += counting_sequence.count_in
+                existing_counting_seqeunce.count_out += counting_sequence.count_out
             else:
                 self.counting_sequences.append(counting_sequence)
 

--- a/src/vccvdv457export/adapter/s2/default.py
+++ b/src/vccvdv457export/adapter/s2/default.py
@@ -54,7 +54,7 @@ class DefaultAdapter(BaseAdapter):
 
             # select primary data and create collector instance
             primary_data = ddb.get_data(operation_day, trip_id, vehicle_id, primary_device_id)
-            collector: PassengerCountingEventCollector = PassengerCountingEventCollector(primary_data)
+            collector: PassengerCountingEventCollector = PassengerCountingEventCollector(primary_data, primary_device_id)
             
             # select device IDs for secondary data
             for secondary_device_id in ddb.get_secondary_device_ids(operation_day, trip_id, vehicle_id, primary_device_id):
@@ -63,7 +63,7 @@ class DefaultAdapter(BaseAdapter):
 
                 # select secondary data 
                 secondary_data = ddb.get_data(operation_day, trip_id, vehicle_id, secondary_device_id)
-                collector.add(secondary_data)
+                collector.add(secondary_data, secondary_device_id)
 
             # call verify method to log every possible invalid dataset
             collector.verify()

--- a/src/vccvdv457export/adapter/s3/default.py
+++ b/src/vccvdv457export/adapter/s3/default.py
@@ -56,7 +56,7 @@ class DefaultAdapter(BaseAdapter):
 
             # select primary data and create collector instance
             primary_data = ddb.get_data(operation_day, trip_id, vehicle_id, primary_device_id)
-            collector: PassengerCountingEventCollector = PassengerCountingEventCollector(primary_data)
+            collector: PassengerCountingEventCollector = PassengerCountingEventCollector(primary_data, primary_device_id)
             
             # select device IDs for secondary data
             for secondary_device_id in ddb.get_secondary_device_ids(operation_day, trip_id, vehicle_id, primary_device_id):
@@ -65,7 +65,7 @@ class DefaultAdapter(BaseAdapter):
 
                 # select secondary data 
                 secondary_data = ddb.get_data(operation_day, trip_id, vehicle_id, secondary_device_id)
-                collector.add(secondary_data, False)
+                collector.add(secondary_data, secondary_device_id, False)
 
             # call verify method to log every possible invalid dataset
             collector.verify()

--- a/src/vccvdv457export/adapter/s3/default.py
+++ b/src/vccvdv457export/adapter/s3/default.py
@@ -285,7 +285,7 @@ class DefaultAdapter(BaseAdapter):
                 # then map all remaining PCEs together to one
                 primary_pce: PassengerCountingEvent = matching_pces[0]
                 for i in range(1, len(matching_pces)):
-                    primary_pce.combine(matching_pces[i])
+                    primary_pce.combine(matching_pces[i], False)
 
                 matched_passenger_counting_events.append(primary_pce)       
         

--- a/src/vccvdv457export/collector.py
+++ b/src/vccvdv457export/collector.py
@@ -10,14 +10,14 @@ from vcclib.dataclasses import PassengerCountingEvent
 
 class PassengerCountingEventCollector:
 
-    def __init__(self, primary_data: List[tuple]) -> None:
-        passenger_counting_events = self._extract_passenger_counting_events(primary_data)
+    def __init__(self, primary_data: List[tuple], device_id: str) -> None:
+        passenger_counting_events = self._extract_passenger_counting_events(primary_data, device_id)
 
         logging.info(f"Initializing {self.__class__.__name__} with {len(passenger_counting_events)} PCEs")
         self._passenger_counting_events = passenger_counting_events
 
-    def add(self, secondary_data: List[tuple], consider_time: bool = True) -> None:
-        passenger_counting_events = self._extract_passenger_counting_events(secondary_data)
+    def add(self, secondary_data: List[tuple], device_id: str, consider_time: bool = True) -> None:
+        passenger_counting_events = self._extract_passenger_counting_events(secondary_data, device_id)
 
         logging.info(f"Combining {len(passenger_counting_events)} secondary PCEs with {len(self._passenger_counting_events)} existing PCEs")
         self._combine_passenger_counting_events(passenger_counting_events, consider_time)
@@ -42,7 +42,7 @@ class PassengerCountingEventCollector:
     def get_passenger_counting_events(self) -> List[PassengerCountingEvent]:
         return sorted(self._passenger_counting_events, key=lambda p: p.end_timestamp())
     
-    def _extract_passenger_counting_events(self, data: List[tuple]) -> List[PassengerCountingEvent]:
+    def _extract_passenger_counting_events(self, data: List[tuple], device_id: str) -> List[PassengerCountingEvent]:
         results: List[PassengerCountingEvent] = list()
 
         pce: PassengerCountingEvent|None = None
@@ -64,6 +64,7 @@ class PassengerCountingEventCollector:
                 pce = PassengerCountingEvent()
                 pce.latitude = row['pce_latitude']
                 pce.longitude = row['pce_longitude']
+                pce.device_id = device_id
 
                 # generate first CountingSequence
                 cs: CountingSequence = self._extract_counting_sequence(row)

--- a/src/vccvdv457export/collector.py
+++ b/src/vccvdv457export/collector.py
@@ -49,11 +49,11 @@ class PassengerCountingEventCollector:
         for row in data:
             if row['stop_id'] is not None and pce is not None and pce.stop is not None and pce.stop.id == row['stop_id']:
                 # generate CountingSequence and add it to existing PCE
-                cs: CountingSequence = self._extract_counting_sequence(row)
+                cs: CountingSequence = self._extract_counting_sequence(row, device_id)
                 pce.counting_sequences.append(cs)
             elif row['begin_timestamp'] is not None and pce is not None and int(pce.begin_timestamp().timestamp()) == row['begin_timestamp']:
                 # generate CountingSequence and add it to existing PCE
-                cs: CountingSequence = self._extract_counting_sequence(row)
+                cs: CountingSequence = self._extract_counting_sequence(row, device_id)
                 pce.counting_sequences.append(cs)
             else:
                 # store current PCE instance

--- a/src/vccvdv457export/collector.py
+++ b/src/vccvdv457export/collector.py
@@ -67,7 +67,7 @@ class PassengerCountingEventCollector:
                 pce.device_id = device_id
 
                 # generate first CountingSequence
-                cs: CountingSequence = self._extract_counting_sequence(row)
+                cs: CountingSequence = self._extract_counting_sequence(row, device_id)                
                 pce.counting_sequences.append(cs)
 
                 # generate stop information
@@ -83,7 +83,7 @@ class PassengerCountingEventCollector:
 
         return results
 
-    def _extract_counting_sequence(self, row: dict) -> CountingSequence:
+    def _extract_counting_sequence(self, row: dict, device_id: str) -> CountingSequence:
         cs: CountingSequence = CountingSequence()
         cs.door_id = row['door_id']
         cs.counting_area_id = row['counting_area_id']
@@ -92,6 +92,7 @@ class PassengerCountingEventCollector:
         cs.end_timestamp = datetime.fromtimestamp(row['end_timestamp'], timezone.utc)
         cs.count_in = row['in']
         cs.count_out = row['out']
+        cs.device_id = device_id
 
         return cs
     


### PR DESCRIPTION
Beim VDV457-Export wurde ein Bug gefixed, welcher dafür gesorgt hat, dass PCE von mehreren Geräten nicht zusammengefasst wurden. 

Außerdem wurden folgende Verbesserungen eingeführt:
- Wenn zwei Geräte Daten für dieselbe Tür-ID liefern, bricht der Export mit einem Fehler ab und verschiebt die Eingangsdaten in den Defective-Ordner
- Wenn ein Gerät eine Durchfahrt und ein anderes Gerät reguläre Zähldaten für dieselbe Tür aufzeichnet, wird die Durchfahrt zu Gunsten der Zählfahrt verworfen