### PR TITLE
BugFix: Behandlung von Durchfahrten und Zusatzhalten

### DIFF
--- a/src/vcclib/dataclasses.py
+++ b/src/vcclib/dataclasses.py
@@ -97,6 +97,11 @@ class PassengerCountingEvent:
         if num_cs_door_0 > 0 and num_cs_door_x > 0:
             self.counting_sequences = [cs for cs in self.counting_sequences if cs.door_id != '0']
 
+        # see #60, take position of secondary PCE if primary PCE has no position
+        if self.latitude == 0.0 or self.longitude == 0.0:
+            self.latitude = pce.latitude
+            self.longitude = pce.longitude
+
     def intersects(self, pce: 'PassengerCountingEvent', consider_position: bool = True, consider_time: bool = True) -> bool:
         # check if stop ID and sequence or after_stop_sequence are the same
         position_intersection: bool = False
@@ -113,7 +118,7 @@ class PassengerCountingEvent:
         time_intersection: bool = False
 
         if consider_time and not (self.is_run_through() and pce.is_run_through()):
-            if self.begin_timestamp() <= pce.end_timestamp() and pce.begin_timestamp() <= self.end_timestamp():
+            if self.end_timestamp() >= pce.begin_timestamp() and pce.end_timestamp() >= self.begin_timestamp():
                 time_intersection = True
         else:
             time_intersection = True

--- a/src/vccvdv457export/adapter/base.py
+++ b/src/vccvdv457export/adapter/base.py
@@ -73,7 +73,7 @@ class BaseAdapter(ABC):
         # check if first and last stop PCE's position matches nominal stop positions
         highest_stop_index: int = trip.stop_times[-1].stop.sequence
 
-        first_stop_pce: PassengerCountingEvent|None = next((pce for pce in passenger_counting_events if pce.stop.sequence == 1), None)
+        first_stop_pce: PassengerCountingEvent|None = next((pce for pce in passenger_counting_events if pce.stop.sequence is not None and pce.stop.sequence == 1), None)
         if first_stop_pce is None:
             self._report(
                 operation_day,

--- a/src/vccvdv457export/adapter/base.py
+++ b/src/vccvdv457export/adapter/base.py
@@ -126,8 +126,19 @@ class BaseAdapter(ABC):
                 )
 
         # check whether each door ID has been counted at least one time in the data
-        expected_door_ids: list[str] = sorted([str(i) for i in range(1, trip.vehicle_num_doors + 1)])
-        counted_door_ids: list[str] = sorted(list({cs.door_id for pce in passenger_counting_events for cs in pce.counting_sequences}))
+        expected_door_ids: list[str] = [str(i) for i in range(1, trip.vehicle_num_doors + 1)]
+        counted_door_ids: list[str] = list({cs.door_id for pce in passenger_counting_events for cs in pce.counting_sequences})
+
+        # raw data may contain a door ID '0' which indicates a run-through PCE
+        # add this to both lists of doors to suppress errors when a door with ID 0 is sent
+        # also sort both lists to have the same order
+        expected_door_ids.append('0')
+        expected_door_ids = sorted(expected_door_ids)
+
+        if '0' not in counted_door_ids:
+            counted_door_ids.append('0')
+        
+        counted_door_ids = sorted(counted_door_ids)
 
         if not expected_door_ids == counted_door_ids:
             self._report(

--- a/src/vccvdv457export/adapter/base.py
+++ b/src/vccvdv457export/adapter/base.py
@@ -99,7 +99,7 @@ class BaseAdapter(ABC):
                     'First PCE position does not match the nominal stop position!'
                 )
 
-        last_stop_pce: PassengerCountingEvent|None = next((pce for pce in passenger_counting_events if pce.stop.sequence == highest_stop_index), None)
+        last_stop_pce: PassengerCountingEvent|None = next((pce for pce in passenger_counting_events if pce.stop is not None and pce.stop.sequence == highest_stop_index), None)
         if last_stop_pce is None:
             self._report(
                 operation_day,

--- a/src/vccvdv457export/adapter/s2/default.py
+++ b/src/vccvdv457export/adapter/s2/default.py
@@ -121,7 +121,6 @@ class DefaultAdapter(BaseAdapter):
             'PassengerCountingEvent': list()
         }
 
-
         run_through_door_id: str = os.getenv('VCC_VDV457_EXPORT_RUN_THROUGH_DOOR_ID', '0')
         for i, pce in enumerate(passenger_counting_events):
             


### PR DESCRIPTION
Die Implementierung des VDV457-Konverters wurde so angepasst, dass Durchfahrten und Zusatzhalte von mehreren Geräten nun sinnvoller zusammengefasst werden. Weiter wurde ein Bug gefixed, welcher den Export der Daten verhindert hat, sobald ein Zusatzhalt aufgezeichnet wurde.