### PR TITLE
MD-Import: Verbesserung bzgl. defekter Objekte

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,6 +32,14 @@
             "group": "build",
             "problemMatcher": [],
             "isBackground": true
+        },
+        {
+            "label": "vccmdimport-dev",
+            "type": "shell",
+            "command": "docker compose -f docker-compose.yaml -f docker-compose.dev.yaml --env-file dev.env up -d --build vcc-md-import",
+            "group": "build",
+            "problemMatcher": [],
+            "isBackground": true
         }
     ]
 }

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -6,6 +6,13 @@ services:
       "
     ports:
       - "5678:5678"
+  vcc-md-import:
+    entrypoint: >
+      sh -c "
+        pip install debugpy && PYTHONPATH=src python -m debugpy --listen 0.0.0.0:5678 --wait-for-client -m vccmdimport main
+      "
+    ports:
+      - "5678:5678"
   vcc-vdv457-export:
     entrypoint: >
       sh -c "

--- a/src/vccmdimport/adapter/csv.py
+++ b/src/vccmdimport/adapter/csv.py
@@ -37,6 +37,13 @@ class CsvAdapter(BaseAdapter):
         vehicle_data = self._internal_read_csv_file(input_directory, 'vehicles.csv')
         for i, record in enumerate(vehicle_data):
             try:
+
+                # check validity of data before inserting
+                # skip the element and log an error, if it is invalid
+                if not record['num_doors'].isdigit():
+                    logging.error(f"Cannot import vehicle {record['name']}, column num_doors has invalid value \"{record['num_doors']}\"!")
+                    continue
+                
                 MasterDataVehicle(
                     name=record['name'],
                     num_doors=int(record['num_doors']),
@@ -63,7 +70,12 @@ class CsvAdapter(BaseAdapter):
 
         object_class_data = self._internal_read_csv_file(input_directory, 'object_classes.csv')
         for i, record in enumerate(object_class_data):
-            try:                
+            try:
+
+                # check validity of data before inserting
+                # skip the element and log an error, if it is invalid
+                # sadly, there's nothing to validate here at all ...
+
                 MasterDataObjectClass(
                     name=record['name'],
                     description=record['description'],


### PR DESCRIPTION
Wenn in den Stammdaten - insbesondere den Fahrzeugen - ein einzelnes Objekt ungültig wird (z.B. durch falschen Wert in der Spalte `num_doors`), bricht nicht mehr der ganze Import ab, sondern es wird nur noch eine Fehlermeldung für das jeweilige Objekt gelogged. Gültige Objekte werden dennoch importiert.

Hinweis: Das gilt natürlich nur, wenn die Stammdatendatei nicht per se defekt ist (z.B. ungültiges Encoding, fehlende Spalten, ...). In diesem Fall bricht der gesamte Import ab, da keine Daten korrekt ermittelt werden können.